### PR TITLE
Twister split by contained components and its link points defined.

### DIFF
--- a/Model/essBuild/essVariables.cxx
+++ b/Model/essBuild/essVariables.cxx
@@ -473,8 +473,8 @@ EssVariables(FuncDataBase& Control)
   Control.addVariable("TwisterXStep",11.0);
   Control.addVariable("TwisterYStep",-62.0);
   Control.addVariable("TwisterZStep",0.0);
-  Control.addVariable("TwisterXYangle",10.0);
-  Control.addVariable("TwisterZangle",0.0);
+  Control.addVariable("TwisterXYAngle",10.0);
+  Control.addVariable("TwisterZAngle",0.0);
   Control.addVariable("TwisterShaftRadius",18.5);
   Control.addVariable("TwisterShaftHeight",120.0+222.4);
   Control.addVariable("TwisterShaftMat","Iron10H2O");

--- a/Model/essBuild/makeESS.cxx
+++ b/Model/essBuild/makeESS.cxx
@@ -645,10 +645,6 @@ makeESS::buildPreWings(Simulation& System, const std::string& lowModType)
 
 void
 makeESS::buildTwister(Simulation& System)
-  /*!
-    Build the reflector twister extraction sytem
-    \param System :: Simulation to use
-   */
 {
   ELog::RegMethod RegA("makeESS","buildTwister");
 
@@ -658,24 +654,33 @@ makeESS::buildTwister(Simulation& System)
   Twister = std::shared_ptr<TwisterModule>(new TwisterModule("Twister"));
   OR.addObject(Twister);
 
-  ELog::EM<<"CALLING addInsertForce [INEFFICIENT] "<<ELog::endWarn;
-  
   Twister->createAll(System,*Bulk,0);
-  attachSystem::addToInsertForced(System, *Bulk, *Twister);
-  attachSystem::addToInsertForced(System, *ShutterBayObj, *Twister);
-  attachSystem::addToInsertSurfCtrl(System, *Twister, PBeam->getCC("Sector0"));
-  attachSystem::addToInsertSurfCtrl(System, *Twister, PBeam->getCC("Sector1"));
+
+  attachSystem::addToInsertForced(System,*Bulk,Twister->getCC("Shaft"));
+  attachSystem::addToInsertForced(System,*Bulk,Twister->getCC("PlugFrame"));
+  attachSystem::addToInsertForced(System,*Bulk,Twister->getCC("ShaftBearing"));
+  
+  attachSystem::addToInsertForced(System,*ShutterBayObj,Twister->getCC("Shaft"));
+  attachSystem::addToInsertSurfCtrl(System,*Twister,PBeam->getCC("Sector0"));
+  attachSystem::addToInsertSurfCtrl(System,*Twister, PBeam->getCC("Sector1"));
   attachSystem::addToInsertControl(System, *Twister, *Reflector);
-  //  attachSystem::addToInsertLineCtrl(System,*Twister,TopAFL->getCC("outer"));
+
+  // split Twister by components
+  // for (const ContainedComp & CC : Twister->getCC()) ...
+  // use LineControl for intersections with flight lines
+  
+  ELog::EM<<"CALLING addInsertForce [INEFFICIENT] "<<ELog::endWarn;
   attachSystem::addToInsertForced(System,*Twister,TopAFL->getCC("outer"));
   attachSystem::addToInsertForced(System,*Twister,TopBFL->getCC("outer"));
   attachSystem::addToInsertForced(System,*Twister,LowAFL->getCC("outer"));
   attachSystem::addToInsertForced(System,*Twister,LowBFL->getCC("outer"));
+
+  attachSystem::addToInsertForced(System,*Twister, Target->getCC("Wheel"));
   attachSystem::addToInsertForced(System,*Twister, Target->getCC("Wheel"));
 
   return;
 }
-  
+
 void 
 makeESS::build(Simulation& System,
 	       const mainSystem::inputParam& IParam)

--- a/Model/essBuildInc/TwisterModule.h
+++ b/Model/essBuildInc/TwisterModule.h
@@ -28,13 +28,13 @@ namespace essSystem
 {
 /*!
   \class TwisterModule
-  \author K. Batkov
+  \author Stuart Ansell / Konstantin Batkov
   \version 1.0
   \date March 2016
   \brief Moderator twister plug
 */
 
-class TwisterModule : public attachSystem::ContainedComp,
+class TwisterModule : public attachSystem::ContainedGroup,
   public attachSystem::FixedOffset,
   public attachSystem::CellMap
 {


### PR DESCRIPTION
I have split the twister by 3 components: "PlugFrame","Shaft","ShaftBearing" and defined its link points. I need your help in defining intersections with flight lines in  makeESS::buildTwister. I still do not understand how to use addToInsertLineCtrl with components of ContainedGroup. I could not find the appropriate addToInsertLineCtrl method.
Also, please check if the numbering (and order) of the link points is appropriate.