### PR TITLE
BasicFlightLine can use cones for tapering

### DIFF
--- a/System/construct/BasicFlightLine.cxx
+++ b/System/construct/BasicFlightLine.cxx
@@ -57,6 +57,7 @@
 #include "Quadratic.h"
 #include "Plane.h"
 #include "Cylinder.h"
+#include "Cone.h"
 #include "Line.h"
 #include "Rules.h"
 #include "varList.h"
@@ -134,12 +135,17 @@ BasicFlightLine::populate(const FuncDataBase& Control)
       lMat.push_back(ModelSupport::EvalMat<int>
 		     (Control,keyName+"LinerMat"+idxStr));
     }  
+
+  tapSurf=Control.EvalDefVar<std::string>(keyName+"TapSurf", "plane");
+  if ( (tapSurf!="plane") && (tapSurf!="cone"))
+    throw ColErr::InvalidLine(tapSurf,keyName+"TapSurf can be either 'plane' or 'cone'");
+
   return;
 }
   
 void
 BasicFlightLine::createUnitVector(const attachSystem::FixedComp& FC,
-				  const long int sideIndex)
+				    const long int sideIndex)
   /*!
     Create the unit vectors
     - Y Points towards the beamline
@@ -179,8 +185,23 @@ BasicFlightLine::createSurfaces()
 
   ModelSupport::buildPlane(SMap,flightIndex+3,Origin-X*(width/2.0),xDircA);
   ModelSupport::buildPlane(SMap,flightIndex+4,Origin+X*(width/2.0),xDircB);
-  ModelSupport::buildPlane(SMap,flightIndex+5,Origin-Z*(height/2.0),zDircA);
-  ModelSupport::buildPlane(SMap,flightIndex+6,Origin+Z*(height/2.0),zDircB);
+
+  // The following ifs check whether the flight line should be tappered
+  // and builds either cone or plane
+  if ((anglesZ[0]>Geometry::zeroTol) && (tapSurf=="cone"))
+    ModelSupport::buildCone(SMap,flightIndex+5,
+			    Origin-Z*(height/2.0),Z,90-anglesZ[0],
+			    Origin[2]>0 ? -1 : 1); // SA: this is weird, but I do not know a better way to do it
+  else
+    ModelSupport::buildPlane(SMap,flightIndex+5,Origin-Z*(height/2.0),zDircA);
+
+  if ((anglesZ[1]>Geometry::zeroTol) && (tapSurf=="cone"))
+    ModelSupport::buildCone(SMap,flightIndex+6,
+			    Origin+Z*(height/2.0),Z,90-anglesZ[1],
+			    Origin[2]>0 ? 1 : -1); // SA: this is weird, but I do not know a better way to do it
+  else
+    ModelSupport::buildPlane(SMap,flightIndex+6,Origin+Z*(height/2.0),-zDircB);
+
 
   double layT(0.0);
   for(size_t i=0;i<nLayer;i++)
@@ -192,10 +213,25 @@ BasicFlightLine::createSurfaces()
 			       Origin-X*(width/2.0)-xDircA*layT,xDircA);
       ModelSupport::buildPlane(SMap,flightIndex+II*10+14,
 			       Origin+X*(width/2.0)+xDircB*layT,xDircB);
-      ModelSupport::buildPlane(SMap,flightIndex+II*10+15,
-			       Origin-Z*(height/2.0)-zDircA*layT,zDircA);
-      ModelSupport::buildPlane(SMap,flightIndex+II*10+16,
-			       Origin+Z*(height/2.0)+zDircB*layT,zDircB);
+
+      if ((anglesZ[0]>Geometry::zeroTol) && (tapSurf=="cone"))
+	ModelSupport::buildCone(SMap,flightIndex+II*10+15,
+				Origin-Z*(height/2.0+layT),Z,90-anglesZ[0],
+				Origin[2]>0 ? -1 : 1);
+      else
+	ModelSupport::buildPlane(SMap,flightIndex+II*10+15,
+				 Origin-Z*(height/2.0)-zDircA*layT,
+				 zDircA);
+
+      if ((anglesZ[1]>Geometry::zeroTol) && (tapSurf=="cone"))
+	ModelSupport::buildCone(SMap,flightIndex+II*10+16,
+				Origin+Z*(height/2.0+layT),Z,90-anglesZ[1],
+				Origin[2]>0 ?  1 : -1);
+      else
+	ModelSupport::buildPlane(SMap,flightIndex+II*10+16,
+				 Origin+Z*(height/2.0)+zDircB*layT,
+				 -zDircB); // '-' in order to have the same sign for planes and corresponding cones
+
     }
 
   // CREATE LINKS
@@ -241,44 +277,43 @@ BasicFlightLine::createObjects(Simulation& System,
   */
 {
   ELog::RegMethod RegA("BasicFlightLine","createObjects");
-  
 
 
   const std::string innerCut=innerFC.getSignedLinkString(innerIndex);
   const std::string outerCut=outerFC.getSignedLinkString(outerIndex);
-  
+
   setLinkSignedCopy(0,innerFC,innerIndex);
   setLinkSignedCopy(1,outerFC,outerIndex);
-  
+
   const int layerIndex=flightIndex+static_cast<int>(nLayer)*10;  
   std::string Out;
-  Out=ModelSupport::getComposite(SMap,layerIndex," 3 -4 5 -6 ");
+  Out=ModelSupport::getComposite(SMap,layerIndex," 3 -4 5 6 ");
   addOuterSurf("outer",Out);
 
   // Inner Void
-  Out=ModelSupport::getComposite(SMap,flightIndex," 3 -4 5 -6 ");
+  Out=ModelSupport::getComposite(SMap,flightIndex," 3 -4 5 6 ");
   addOuterSurf("inner",Out);
-
 
   // Make inner object
   Out+=innerCut+outerCut;
   System.addCell(MonteCarlo::Qhull(cellIndex++,innerMat,0.0,Out));
+  setCell("Inner", cellIndex-1); // used in WedgedFlightLine
   CellMap::addCell("innerVoid",cellIndex-1);
+
   //Flight layers:
   for(size_t i=0;i<nLayer;i++)
     {
       const int II(static_cast<int>(i));
       Out=ModelSupport::getComposite(SMap,flightIndex+10*II,
-				     "13 -14 15 -16 (-3:4:-5:6) ");
+				     "13 -14 15 16 (-3:4:-5:-6) ");
       Out+=innerCut+outerCut;
       System.addCell(MonteCarlo::Qhull(cellIndex++,lMat[i],0.0,Out));
       CellMap::addCell("Layer"+StrFunc::makeString(i+1),cellIndex-1);
-    }      
+    }
   
   return;
 }
 
-  
 void
 BasicFlightLine::createAll(Simulation& System,
 			   const attachSystem::FixedComp& originFC,
@@ -309,7 +344,4 @@ BasicFlightLine::createAll(Simulation& System,
   return;
 }
 
-
-
-  
 }  // NAMESPACE moderatorSystem

--- a/System/constructInc/BasicFlightLine.h
+++ b/System/constructInc/BasicFlightLine.h
@@ -1,7 +1,7 @@
 /********************************************************************* 
   CombLayer : MCNP(X) Input builder
  
- * File:   constructInc/BasicFlightLine.h
+ * File:   constructInc/TiltedFlightLine.h
  *
  * Copyright (c) 2004-2015 by Stuart Ansell
  *
@@ -30,16 +30,16 @@ namespace moderatorSystem
 /*!
   \class BasicFlightLine
   \version 1.0
-  \author S. Ansell
-  \date April 2011
+  \author S. Ansell, K. Batkov
+  \date Oct 2015
   \brief BasicFlightLine [insert object]
 */
 
-class BasicFlightLine : public attachSystem::ContainedGroup,
+class BasicFlightLine : public attachSystem::ContainedGroup, 
   public attachSystem::FixedComp,
   public attachSystem::CellMap
 {
- private:
+ protected:
   
   const int flightIndex;        ///< Index of surface offset
   int cellIndex;                ///< Cell index
@@ -60,6 +60,8 @@ class BasicFlightLine : public attachSystem::ContainedGroup,
   size_t nLayer;                ///< Number of layers
   std::vector<double> lThick;   ///< Linear Thickness 
   std::vector<int> lMat;        ///< Layer Material
+
+  std::string tapSurf;          ///< Type of surfaces used for tapering (plane|cone)
 
   std::string attachRule;       ///< Attached rule
   
@@ -85,7 +87,6 @@ class BasicFlightLine : public attachSystem::ContainedGroup,
 		 const attachSystem::FixedComp&,const long int,
 		 const attachSystem::FixedComp&,const long int);
 
-  
 };
 
 }


### PR DESCRIPTION
Added a flag in BasicFlightLine to use either planes or cones for tapering.
Please check/correct the lines with comments starting with "SA:".