### PR TITLE
Set MCNP version in DefUnitsESS

### DIFF
--- a/Main/ess.cxx
+++ b/Main/ess.cxx
@@ -117,7 +117,9 @@ main(int argc,char* argv[])
       mainSystem::setDefUnits(SimPtr->getDataBase(),IParam);
       InputModifications(SimPtr,IParam,Names);
       mainSystem::setMaterialsDataBase(IParam);
-            
+
+      SimPtr->setMCNPversion(IParam.getValue<int>("mcnp"));
+
       essSystem::makeESS ESSObj;
       World::createOuterObjects(*SimPtr);
       ESSObj.build(*SimPtr,IParam);

--- a/System/process/MainProcess.cxx
+++ b/System/process/MainProcess.cxx
@@ -403,9 +403,6 @@ createSimulation(inputParam& IParam,
   else 
     SimPtr=new Simulation;
 
-  // has default value
-  SimPtr->setMCNPversion(IParam.getValue<int>("mcnp"));
-  
   SimPtr->setCmdLine(cmdLine.str());        // set full command line
 
   return SimPtr;


### PR DESCRIPTION
I suggest to move the line
```SimPtr->setMCNPversion(IParam.getValue<int>("mcnp"));```
from `mainSystem::createSimulation` into the `main` function after calling `mainSystem::setDefUnits` since otherwise the MCNP version can't be set in that method.

I need it since in the ButterflyEngineering branch I would like to call `A.setOption("mcnp", "10")` if the geometry is being generated with `-defaultConfig neutronics` arguments.