### PR TITLE
muBeam: now can be compiled with new boost

### DIFF
--- a/build/BlockShutter.cxx
+++ b/build/BlockShutter.cxx
@@ -404,13 +404,15 @@ BlockShutter::getExitTrack() const
 
   std::vector<zbTYPE>::const_iterator ac=
     find_if(iBlock.begin(),iBlock.end(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBase::getMat,_1),b4cMat));
+	    std::bind(std::equal_to<int>(),
+			std::bind<int>(&collInsertBase::getMat,
+				       std::placeholders::_1),b4cMat));
 
   std::vector<zbTYPE>::const_reverse_iterator bc=
     find_if(iBlock.rbegin(),iBlock.rend(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBase::getMat,_1),b4cMat));
+	    std::bind(std::equal_to<int>(),
+			std::bind<int>(&collInsertBase::getMat,
+				       std::placeholders::_1),b4cMat));
 
   if (ac==iBlock.end() || bc==iBlock.rend())
     {
@@ -440,8 +442,9 @@ BlockShutter::getExitPoint() const
   
   std::vector<zbTYPE>::const_reverse_iterator bc=
     find_if(iBlock.rbegin(),iBlock.rend(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBase::getMat,_1),b4cMat));
+	    std::bind(std::equal_to<int>(),
+			std::bind<int>(&collInsertBase::getMat,
+				       std::placeholders::_1),b4cMat));
   if (bc==iBlock.rend())
     {
       ELog::EM<<"Problem finding B4C blocks"<<ELog::endCrit;
@@ -480,13 +483,15 @@ BlockShutter::setTwinComp()
     
   std::vector<zbTYPE>::const_iterator ac=
     find_if(iBlock.begin(),iBlock.end(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBase::getMat,_1),b4cMat));
+	    std::bind(std::equal_to<int>(),
+			std::bind<int>(&collInsertBase::getMat,
+				       std::placeholders::_1),b4cMat));
 
   std::vector<zbTYPE>::const_reverse_iterator bc=
     find_if(iBlock.rbegin(),iBlock.rend(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBase::getMat,_1),b4cMat));
+	    std::bind(std::equal_to<int>(),
+			std::bind<int>(&collInsertBase::getMat,
+				       std::placeholders::_1),b4cMat));
 
   if (ac==iBlock.end() || bc==iBlock.rend())
     {
@@ -527,14 +532,16 @@ BlockShutter::createFrontViewPoints() const
 
   std::vector<zbTYPE>::const_iterator ba=
     find_if(iBlock.begin(),iBlock.end(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBase::getMat,_1),b4cMat));
+	    std::bind(std::equal_to<int>(),
+			std::bind<int>(&collInsertBase::getMat,
+				       std::placeholders::_1),b4cMat));
   if (ba!=iBlock.end())
     {
       std::vector<zbTYPE>::const_iterator bb=
 	find_if(ba+1,iBlock.end(),
-		boost::bind(std::equal_to<int>(),
-		    boost::bind<int>(&collInsertBase::getMat,_1),b4cMat));
+		std::bind(std::equal_to<int>(),
+		    std::bind<int>(&collInsertBase::getMat,
+				   std::placeholders::_1),b4cMat));
       if (bb!=iBlock.end())
 	Opts=(*ba)->viewWindow(bb->get());
       ELog::EM<<"Front window "<<ELog::endDebug;
@@ -558,14 +565,16 @@ BlockShutter::createBackViewPoints() const
 
   std::vector<zbTYPE>::const_reverse_iterator ba=
     find_if(iBlock.rbegin(),iBlock.rend(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBase::getMat,_1),b4cMat));
+	    std::bind(std::equal_to<int>(),
+			std::bind<int>(&collInsertBase::getMat,
+				       std::placeholders::_1),b4cMat));
   if (ba!=iBlock.rend())
     {
       std::vector<zbTYPE>::const_reverse_iterator bb=
 	find_if(ba+1,iBlock.rend(),
-		boost::bind(std::equal_to<int>(),
-		    boost::bind<int>(&collInsertBase::getMat,_1),b4cMat));
+		std::bind(std::equal_to<int>(),
+		    std::bind<int>(&collInsertBase::getMat,
+				   std::placeholders::_1),b4cMat));
       if (bb!=iBlock.rend())
 	Opts=(*ba)->viewWindow(bb->get());
       ELog::EM<<"Back window "<<ELog::endDebug;

--- a/geometry/localRotate.cxx
+++ b/geometry/localRotate.cxx
@@ -122,7 +122,7 @@ localRotate::reverseRotate(const Geometry::Vec3D& V) const
   void (transComp::*fn)(Geometry::Vec3D&) const =  
     &transComp::reverse;
   for_each(Transforms.rbegin(),Transforms.rend(),
-	   boost::bind<void>(fn,_1,boost::ref(Vpt)));
+	   std::bind<void>(fn,std::placeholders::_1,boost::ref(Vpt)));
   return Vpt;
 }
 
@@ -138,7 +138,7 @@ localRotate::calcRotate(const Geometry::Vec3D& V) const
   // Helper func ptr for boost since can't resolve type as overloaded:
   void (transComp::*fn)(Geometry::Vec3D&) const =  &transComp::apply;
   for_each(Transforms.begin(),Transforms.end(),
-	   boost::bind<void>(fn,_1,boost::ref(Vpt)));
+	   std::bind<void>(fn,std::placeholders::_1,boost::ref(Vpt)));
   return Vpt;
 }
 
@@ -150,7 +150,7 @@ localRotate::axisRotate(Geometry::Vec3D& V) const
   */
 {
   for_each(Transforms.begin(),Transforms.end(),
-	   boost::bind<void>(&transComp::applyAxis,_1,boost::ref(V)));
+	   std::bind<void>(&transComp::applyAxis,std::placeholders::_1,boost::ref(V)));
   return;
 }
 
@@ -162,7 +162,7 @@ localRotate::axisRotateReverse(Geometry::Vec3D& V) const
   */
 {
   for_each(Transforms.rbegin(),Transforms.rend(),
-	   boost::bind<void>(&transComp::reverseAxis,_1,boost::ref(V)));
+	   std::bind<void>(&transComp::reverseAxis,std::placeholders::_1,boost::ref(V)));
   return;
 }
 
@@ -201,7 +201,7 @@ localRotate::applyFull(Geometry::Surface* SPtr) const
 {
   void (transComp::*fn)(Geometry::Surface*) const =  &transComp::apply;
   for_each(Transforms.begin(),Transforms.end(),
-	   boost::bind<void>(fn,_1,SPtr));
+	   std::bind<void>(fn,std::placeholders::_1,SPtr));
   return;
 }
 
@@ -214,7 +214,7 @@ localRotate::applyFull(MonteCarlo::Object* OPtr) const
 {
   void (transComp::*fn)(MonteCarlo::Object*) const =  &transComp::apply;
   for_each(Transforms.begin(),Transforms.end(),
-	   boost::bind<void>(fn,_1,OPtr));
+	   std::bind<void>(fn,std::placeholders::_1,OPtr));
   return;
 }
 
@@ -227,7 +227,7 @@ localRotate::applyFull(Geometry::Vec3D& Pt) const
 {
   void (transComp::*fn)(Geometry::Vec3D&) const =  &transComp::apply;
   for_each(Transforms.begin(),Transforms.end(),
-	   boost::bind<void>(fn,_1,boost::ref(Pt)));
+	   std::bind<void>(fn,std::placeholders::_1,boost::ref(Pt)));
   return;
 }
 

--- a/physics/PhysicsCards.cxx
+++ b/physics/PhysicsCards.cxx
@@ -146,8 +146,9 @@ PhysicsCards::addHistpCells(const std::vector<int>& AL)
   void (tallySystem::NList<int>::*fn)(const int&) = 
     &tallySystem::NList<int>::addComp;
 
-  for_each(AL.begin(),AL.end(),
-	   boost::bind<void>(fn,boost::ref(histpCells),_1));
+  for(const int CellN : AL)
+    histpCells.addComp(CellN);
+
   return;
 }
 
@@ -273,15 +274,16 @@ PhysicsCards::processCard(const std::string& Line)
         {
 	  std::vector<std::string> part;
 	  boost::split(part,Item,boost::is_any_of(","));
-	  for_each(part.begin(),part.end(),
-		   boost::bind(&boost::trim<std::string>,_1,std::locale()));
+	  for(std::string& PStr : part)
+	    boost::trim(PStr,std::locale());
 	  // ensure no empty particles
 	  part.erase(remove_if(part.begin(),part.end(),
-			       boost::bind<bool>(&std::string::empty,_1)),
+			       std::bind<bool>(&std::string::empty,
+					       std::placeholders::_1)),
 		     part.end());
 	  PhysCard& PC(PhysCards.back());
-	  for_each(part.begin(),part.end(), 
-		   boost::bind(&PhysCard::addElm,boost::ref(PC),_1));
+	  for(const std::string& PStr : part)
+	    PC.addElm(PStr);
 	  // Strip and process numbers / j
 	  for(size_t i=0;i<5 && !Comd.empty();i++)
 	    {
@@ -310,7 +312,8 @@ PhysicsCards::setEnergyCut(const double E)
   */
 {
   for_each(PhysCards.begin(),PhysCards.end(),
-	   boost::bind(&PhysCard::setEnergyCut,_1,E));
+	   std::bind(&PhysCard::setEnergyCut,
+		     std::placeholders::_1,E));
   sdefCard.cutEnergy(E);
   return;
 }
@@ -367,7 +370,8 @@ PhysicsCards::addPhysCard(const std::string& Key,
       {
 
 	ac=find_if(PList.begin(),PList.end(),
-		  boost::bind(&PhysCard::hasElm,*vc,_1));
+		  std::bind(&PhysCard::hasElm,*vc,
+			    std::placeholders::_1));
 	// If item , add all additional items to the card
 	if (ac!=PList.end())
 	  {
@@ -402,9 +406,8 @@ PhysicsCards::setCellNumbers(const std::vector<int>& cellInfo,
 				   impValue.size(),
 				   "PhysicsCards.setCellNumbers");
 
-  for_each(ImpCards.begin(),ImpCards.end(),
-	   boost::bind<void>(&PhysImp::setAllCells,_1,boost::cref(cellInfo),
-			     boost::cref(impValue)));
+  for(PhysImp& PI : ImpCards)
+    PI.setAllCells(cellInfo,impValue);
 
   Volume.setCells(cellInfo,1.0);
   return;
@@ -426,13 +429,15 @@ PhysicsCards::setCells(const std::string& Type,
 {
   std::vector<PhysImp>::iterator vc;
   vc=find_if(ImpCards.begin(),ImpCards.end(),
-	     boost::bind(&PhysImp::isType,_1,Type));
+	     std::bind(&PhysImp::isType,
+		       std::placeholders::_1,Type));
   while(vc!=ImpCards.end())
     {
       vc->setCells(cellInfo,defValue);
       vc++;
       vc=find_if(vc,ImpCards.end(),
-		 boost::bind(&PhysImp::isType,_1,Type));
+		 std::bind(&PhysImp::isType,
+			   std::placeholders::_1,Type));
     }
   return;
 }
@@ -452,13 +457,15 @@ PhysicsCards::setCells(const std::string& Type,
 {
   std::vector<PhysImp>::iterator vc;
   vc=find_if(ImpCards.begin(),ImpCards.end(),
-	     boost::bind(&PhysImp::isType,_1,Type));
+	     std::bind(&PhysImp::isType,
+		       std::placeholders::_1,Type));
   while(vc!=ImpCards.end())
     {
       vc->setValue(cellID,defValue);
       vc++;
       vc=find_if(vc,ImpCards.end(),
-		 boost::bind(&PhysImp::isType,_1,Type));
+		 std::bind(&PhysImp::isType,
+			   std::placeholders::_1,Type));
     }
   return;
 }
@@ -480,7 +487,8 @@ PhysicsCards::setCells(const std::string& Type,
 {
   std::vector<PhysImp>::iterator vc;
   vc=find_if(ImpCards.begin(),ImpCards.end(),
-	     boost::bind(&PhysImp::isType,_1,Type));
+	     std::bind(&PhysImp::isType,
+		       std::placeholders::_1,Type));
   while(vc!=ImpCards.end())
     {
       if (vc->hasElm(Particle))
@@ -490,7 +498,8 @@ PhysicsCards::setCells(const std::string& Type,
 	}
       vc++;
       vc=find_if(vc,ImpCards.end(),
-		 boost::bind(&PhysImp::isType,_1,Type));
+		 std::bind(&PhysImp::isType,
+			   std::placeholders::_1,Type));
     }
   throw ColErr::InContainerError<std::string>(Type+"::"+Particle,
 				 "PhysicsCars::setCells:");
@@ -505,7 +514,8 @@ PhysicsCards::removeCell(const int Index)
   */
 {
   for_each(ImpCards.begin(),ImpCards.end(),
-	   boost::bind(&PhysImp::removeCell,_1,Index));
+	   std::bind(&PhysImp::removeCell,
+		     std::placeholders::_1,Index));
   return;
 }
 
@@ -539,14 +549,16 @@ PhysicsCards::getPhysImp(const std::string& type,const std::string& particle)
 
   std::vector<PhysImp>::iterator vc;
   vc=find_if(ImpCards.begin(),ImpCards.end(),
-	     boost::bind(&PhysImp::isType,_1,type));
+	     std::bind(&PhysImp::isType,
+		       std::placeholders::_1,type));
   while(vc!=ImpCards.end())
     {
       if (vc->hasElm(particle))
 	return *vc;
       vc++;
       vc=find_if(vc,ImpCards.end(),
-		 boost::bind(&PhysImp::isType,_1,type));
+		 std::bind(&PhysImp::isType,
+			   std::placeholders::_1,type));
     }
   throw ColErr::InContainerError<std::string>(particle,RegA.getFull());
 }
@@ -564,14 +576,16 @@ PhysicsCards::getPhysImp(const std::string& type,const std::string& particle) co
 {
   std::vector<PhysImp>::const_iterator vc;
   vc=find_if(ImpCards.begin(),ImpCards.end(),
-	     boost::bind(&PhysImp::isType,_1,type));
+	     std::bind(&PhysImp::isType,
+		       std::placeholders::_1,type));
   while(vc!=ImpCards.end())
     {
       if (vc->hasElm(particle))
 	return *vc;
       vc++;
       vc=find_if(vc,ImpCards.end(),
-		 boost::bind(&PhysImp::isType,_1,type));
+		 std::bind(&PhysImp::isType,
+			   std::placeholders::_1,type));
     }
   throw ColErr::InContainerError<std::string>(type+particle,"PhysicsCards::getImp const");
 }
@@ -612,7 +626,8 @@ PhysicsCards::substituteCell(const int oldCell,const int newCell)
   sdefCard.substituteCell(oldCell,newCell);
   histpCells.changeItem(oldCell,newCell);
   for_each(ImpCards.begin(),ImpCards.end(),
-	  boost::bind(&PhysImp::renumberCell,_1,oldCell,newCell));
+	  std::bind(&PhysImp::renumberCell,
+		    std::placeholders::_1,oldCell,newCell));
   Volume.renumberCell(oldCell,newCell);
   return;
 }
@@ -696,14 +711,16 @@ PhysicsCards::write(std::ostream& OX,
   Volume.write(OX,cellOutOrder);
   
   for_each(ImpCards.begin(),ImpCards.end(),
-	   boost::bind<void>(&PhysImp::write,_1,boost::ref(OX),
+	   std::bind<void>(&PhysImp::write,
+			   std::placeholders::_1,boost::ref(OX),
 			     boost::ref(cellOutOrder)));
 
   for_each(PhysCards.begin(),PhysCards.end(),
-	   boost::bind<void>(&PhysCard::write,_1,boost::ref(OX)));
+	   std::bind<void>(&PhysCard::write,
+			   std::placeholders::_1,boost::ref(OX)));
   
-  for_each(Basic.begin(),Basic.end(),
-	   boost::bind2nd(&StrFunc::writeMCNPX,OX));
+  for(const std::string& PC : Basic)
+    StrFunc::writeMCNPX(PC,OX);
 
   LEA.write(OX);
 

--- a/src/Simulation.cxx
+++ b/src/Simulation.cxx
@@ -669,11 +669,10 @@ Simulation::removeDeadSurfaces(const int placeFlag)
 	Dead.push_back(sc->first);
     }
   // Dead:
-  ModelSupport::surfIndex& SurI=ModelSupport::surfIndex::Instance();  
-  for_each(Dead.begin(),Dead.end(),
-  	   boost::bind<void>(&ModelSupport::surfIndex::deleteSurface,
-  			     boost::ref(SurI),_1));
-  
+  ModelSupport::surfIndex& SurI=ModelSupport::surfIndex::Instance();
+    for(const int DSurf : Dead)
+    SurI.deleteSurface(DSurf);
+
   return 0;
 }
 
@@ -1026,9 +1025,9 @@ Simulation::removeNullSurfaces()
 	  dead.push_back(keyN);
 	}
     }
-  for_each(dead.begin(),dead.end(),
-	   boost::bind<void>(&ModelSupport::surfIndex::deleteSurface,
-			     boost::ref(SI),_1));
+  for(const int DSurf : dead)
+    SI.deleteSurface(DSurf);
+
   return 0;
 }
 
@@ -1506,8 +1505,9 @@ Simulation::writeTally(std::ostream& OX) const
   // uses the mathSupport:::PSecond
   // _1 refers back to the TItem pair<int,tally*>
   for_each(TItem.begin(),TItem.end(),
-	   boost::bind(&tallySystem::Tally::write,
-	  boost::bind(MapSupport::PSecond<TallyTYPE>(),_1),
+	   std::bind(&tallySystem::Tally::write,
+	  std::bind(MapSupport::PSecond<TallyTYPE>(),
+		    std::placeholders::_1),
 		       boost::ref(OX)));
   return;
 }
@@ -1993,8 +1993,9 @@ Simulation::renumberCells(const std::vector<int>& cOffset,
 	{
 	  PhysPtr->substituteCell(cNum,nNum);
 	  for_each(TItem.begin(),TItem.end(),
-		   boost::bind(&tallySystem::Tally::renumberCell,
-			       boost::bind(&TallyTYPE::value_type::second,_1),
+		   std::bind(&tallySystem::Tally::renumberCell,
+			       std::bind(&TallyTYPE::value_type::second,
+					 std::placeholders::_1),
 			       cNum,nNum));
 	}
       ELog::RN<<"Cell Changed :"<<cNum<<" "<<nNum<<ELog::endBasic;

--- a/zoom/ZoomShutter.cxx
+++ b/zoom/ZoomShutter.cxx
@@ -380,14 +380,18 @@ ZoomShutter::getExitTrack() const
 
   const int b4cMat(47);
   std::vector<collInsertBlock>::const_iterator ac=
-    find_if(iBlock.begin(),iBlock.end(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBlock::getMat,_1),b4cMat));
+        find_if(iBlock.begin(),iBlock.end(),
+	    [b4cMat](const collInsertBlock& cb)
+	    {
+	      return (cb.getMat()==b4cMat);
+	    });
 
   std::vector<collInsertBlock>::const_reverse_iterator bc=
     find_if(iBlock.rbegin(),iBlock.rend(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBlock::getMat,_1),b4cMat));
+	    [b4cMat](const collInsertBlock& cb)
+	    {
+	      return (cb.getMat()==b4cMat);
+	    });
 
   if (ac==iBlock.end() || bc==iBlock.rend())
     {
@@ -419,8 +423,11 @@ ZoomShutter::getExitPoint() const
 
   std::vector<collInsertBlock>::const_reverse_iterator bc=
     find_if(iBlock.rbegin(),iBlock.rend(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBlock::getMat,_1),b4cMat));
+	    [b4cMat](const collInsertBlock& cb)
+	    {
+	      return (cb.getMat()==b4cMat);
+	    });
+
   if (bc==iBlock.rend())
     {
       ELog::EM<<"Problem finding B4C blocks"<<ELog::endCrit;
@@ -459,14 +466,18 @@ ZoomShutter::setTwinComp()
     
   const int b4cMat(47);
   std::vector<collInsertBlock>::const_iterator ac=
-    find_if(iBlock.begin(),iBlock.end(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBlock::getMat,_1),b4cMat));
+        find_if(iBlock.begin(),iBlock.end(),
+	    [b4cMat](const collInsertBlock& cb)
+	    {
+	      return (cb.getMat()==b4cMat);
+	    });
 
   std::vector<collInsertBlock>::const_reverse_iterator bc=
     find_if(iBlock.rbegin(),iBlock.rend(),
-	    boost::bind(std::equal_to<int>(),
-			boost::bind<int>(&collInsertBlock::getMat,_1),b4cMat));
+	    [b4cMat](const collInsertBlock& cb)
+	    {
+	      return (cb.getMat()==b4cMat);
+	    });
 
   if (ac==iBlock.end() || bc==iBlock.rend())
     {


### PR DESCRIPTION
This pull request is for the muBeam branch.
I tried to build muBeam from the muBeam branch, but failed with several boost-related complains.
Therefore I modified the boost-related stuff in order to compile with the modern boost version:

1. boost::bind replaced with std::bind
2. when needed, for_each loop replaced with range based for loop (**needs c++11**)

Now muBeam can be compiled (at least on my laptop).