### PR TITLE
Ci test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 language: cpp
 matrix:
    include:
+     # linux - g++ 4.9
      - os: linux
        addons:
          apt:
@@ -12,13 +13,12 @@ matrix:
              - g++-4.9
              - cmake
              - cmake-data
-             - build-essential
-             - libboost-regex-dev
              - libgsl0-dev
              - libboost-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+     # linux - g++ 5
      - os: linux
        addons:
          apt:
@@ -29,13 +29,12 @@ matrix:
              - g++-5
              - cmake
              - cmake-data
-             - build-essential
-             - libboost-regex-dev
              - libgsl0-dev
              - libboost-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+     # linux - g++ 6
      - os: linux
        addons:
          apt:
@@ -46,13 +45,12 @@ matrix:
              - g++-6
              - cmake
              - cmake-data
-             - build-essential
-             - libboost-regex-dev
              - libgsl0-dev
              - libboost-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+     # linux - g++ 7
      - os: linux
        addons:
          apt:
@@ -63,13 +61,12 @@ matrix:
              - g++-7
              - cmake
              - cmake-data
-             - build-essential
-             - libboost-regex-dev
              - libgsl0-dev
              - libboost-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+     # linux - clang 3.7 with default g++
      - os: linux
        addons:
          apt:
@@ -81,13 +78,12 @@ matrix:
              - clang-3.7
              - cmake
              - cmake-data
-             - build-essential
-             - libboost-regex-dev
              - libgsl0-dev
              - libboost-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
+     # linux - clang 3.8 with g++6
      - os: linux
        addons:
          apt:
@@ -100,13 +96,12 @@ matrix:
              - clang-3.8
              - cmake
              - cmake-data
-             - build-essential
-             - libboost-regex-dev
              - libgsl0-dev
              - libboost-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+     # linux - clang 3.9 with g++6
      - os: linux
        addons:
          apt:
@@ -119,13 +114,12 @@ matrix:
              - clang-3.9
              - cmake
              - cmake-data
-             - build-essential
-             - libboost-regex-dev
              - libgsl0-dev
              - libboost-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+     # linux - clang 4.0 with g++6
      - os: linux
        addons:
          apt:
@@ -138,13 +132,12 @@ matrix:
              - clang-4.0
              - cmake
              - cmake-data
-             - build-essential
-             - libboost-regex-dev
              - libgsl0-dev
              - libboost-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+     # linux - clang 5.0 with g++6
      - os: linux
        addons:
          apt:
@@ -157,8 +150,6 @@ matrix:
              - clang-5.0
              - cmake
              - cmake-data
-             - build-essential
-             - libboost-regex-dev
              - libgsl0-dev
              - libboost-dev
              - libboost-filesystem-dev
@@ -167,8 +158,6 @@ matrix:
 before_install:
   - eval "${MATRIX_EVAL}" 
   - cmake -version
-  - gcc --version
-  - clang --version
   - echo $CC
   - echo $CXX 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
       - gcc
       - build-essential
       - libboost-regex-dev
-      - libgsl-dev
+      - libgsl0-dev
       - libboost-dev
       - libboost-filesystem-dev
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,99 @@
 # test of travis ci for comblayer
 language: cpp
-os:
-  - linux
-compiler:
-  - gcc
-  - clang 
-addons:
-  apt:
-    sources:
-      - george-edison55-precise-backports
-    packages:
-      - cmake
-      - cmake-data
-      - gcc
-      - build-essential
-      - libboost-regex-dev
-      - libgsl0-dev
-      - libboost-dev
-      - libboost-filesystem-dev
+matrix:
+   include:
+     - os: linux
+       addons:
+         apt:
+           sources:
+             - ubuntu-toolchain-r-test
+             - george-edison55-precise-backports
+           packages:
+             - g++-5
+             - cmake
+             - cmake-data
+             - build-essential
+             - libboost-regex-dev
+             - libgsl0-dev
+             - libboost-dev
+             - libboost-filesystem-dev
+       env:
+          -MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+     - os: linux
+       addons:
+         apt:
+           sources:
+             - ubuntu-toolchain-r-test
+             - george-edison55-precise-backports
+           packages:
+             - g++-6
+             - cmake
+             - cmake-data
+             - build-essential
+             - libboost-regex-dev
+             - libgsl0-dev
+             - libboost-dev
+             - libboost-filesystem-dev
+       env:
+          -MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+     - os: linux
+       addons:
+         apt:
+           sources:
+             - ubuntu-toolchain-r-test
+             - george-edison55-precise-backports
+           packages:
+             - g++-7
+             - cmake
+             - cmake-data
+             - build-essential
+             - libboost-regex-dev
+             - libgsl0-dev
+             - libboost-dev
+             - libboost-filesystem-dev
+       env:
+          -MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+     - os: linux
+       addons:
+         apt:
+           sources:
+             - ubuntu-toolchain-r-test
+             - llvm-toolchain-precise-3.7
+             - george-edison55-precise-backports
+           packages:
+             - clang-3.7
+             - cmake
+             - cmake-data
+             - build-essential
+             - libboost-regex-dev
+             - libgsl0-dev
+             - libboost-dev
+             - libboost-filesystem-dev
+       env:
+          -MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
+     - os: linux
+       addons:
+         apt:
+           sources:
+             - ubuntu-toolchain-r-test
+             - llvm-toolchain-precise-3.8
+             - george-edison55-precise-backports
+           packages:
+             - clang-3.8
+             - cmake
+             - cmake-data
+             - build-essential
+             - libboost-regex-dev
+             - libgsl0-dev
+             - libboost-dev
+             - libboost-filesystem-dev
+       env:
+          -MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
 before_install:
+  - eval "$(MATRIX_EVAL)" 
   - cmake -version
   - gcc --version
+  - clang --version
 script:
   - ./CMake.pl -O -g++=$CXX
   - cmake ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ addons:
 before_install:
   - cmake -version
   - gcc --version
-  - sudo apt-get update
 script:
   - ./CMake.pl -O -g++=$CXX
   - cmake ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ compiler:
 addons:
   apt:
     sources:
-      - george-edison55-backports
+      - george-edison55-precise-backports
     packages:
       - cmake
       - cmake-data

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
              - llvm-toolchain-precise-3.8
              - george-edison55-precise-backports
            packages:
-             - g++-7
+             - g++-6
              - clang-3.8
              - cmake
              - cmake-data
@@ -115,7 +115,7 @@ matrix:
              - llvm-toolchain-trusty-3.9
              - george-edison55-precise-backports
            packages:
-             - g++-7
+             - g++-6
              - clang-3.9
              - cmake
              - cmake-data
@@ -134,7 +134,7 @@ matrix:
              - llvm-toolchain-trusty-4.0
              - george-edison55-precise-backports
            packages:
-             - g++-7
+             - g++-6
              - clang-4.0
              - cmake
              - cmake-data
@@ -153,7 +153,7 @@ matrix:
              - llvm-toolchain-trusty-5.0
              - george-edison55-precise-backports
            packages:
-             - g++-7
+             - g++-6
              - clang-5.0
              - cmake
              - cmake-data

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 # test of travis ci for comblayer
-language: c
+language: cpp
 os:
   - linux
 compiler:
   - gcc
+  - clang 
 addons:
   apt:
     sources:
@@ -19,11 +20,14 @@ addons:
       - libboost-filesystem-dev
 before_install:
   - cmake -version
+  - gcc --version
+  - sudo apt-get update
 script:
-  - ./CMake.pl -O -g++=g++
+  - ./CMake.pl -O -g++=$CXX
   - cmake ./
   - make -j6
-  - ./fullBuild -r fbtest.o 
   - ./testMain -1 -1 -1
+  - ./fullBuild -r fbtest 
+
 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,7 @@ script:
   - ./CMake.pl -O -g++=g++
   - cmake ./
   - make -j6
-  - fullBuild -r fbtest.o 
+  - ./fullBuild -r fbtest.o 
+  - ./testMain -1 -1 -1
+
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # test of travis ci for comblayer
+language: cpp
 matrix:
    include:
      - os: linux
@@ -17,7 +18,7 @@ matrix:
              - libboost-dev
              - libboost-filesystem-dev
        env:
-          -MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+          - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
      - os: linux
        addons:
          apt:
@@ -34,7 +35,7 @@ matrix:
              - libboost-dev
              - libboost-filesystem-dev
        env:
-          -MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+          - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
      - os: linux
        addons:
          apt:
@@ -51,7 +52,7 @@ matrix:
              - libboost-dev
              - libboost-filesystem-dev
        env:
-          -MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+          - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
      - os: linux
        addons:
          apt:
@@ -69,7 +70,7 @@ matrix:
              - libboost-dev
              - libboost-filesystem-dev
        env:
-          -MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
+          - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
      - os: linux
        addons:
          apt:
@@ -87,9 +88,9 @@ matrix:
              - libboost-dev
              - libboost-filesystem-dev
        env:
-          -MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+          - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
 before_install:
-  - eval "$(MATRIX_EVAL)" 
+  - eval "${MATRIX_EVAL}" 
   - cmake -version
   - gcc --version
   - clang --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -97,6 +97,7 @@ matrix:
              - george-edison55-precise-backports
            packages:
              - clang-3.8
+             - g++-7
              - cmake
              - cmake-data
              - build-essential
@@ -110,10 +111,12 @@ matrix:
        addons:
          apt:
            sources:
+             - ubuntu-toolchain-r-test
              - llvm-toolchain-trusty-3.9
              - george-edison55-precise-backports
            packages:
              - clang-3.9
+             - g++-7
              - cmake
              - cmake-data
              - build-essential
@@ -127,10 +130,12 @@ matrix:
        addons:
          apt:
            sources:
+             - ubuntu-toolchain-r-test
              - llvm-toolchain-trusty-4.0
              - george-edison55-precise-backports
            packages:
              - clang-4.0
+             - g++-7
              - cmake
              - cmake-data
              - build-essential
@@ -144,10 +149,12 @@ matrix:
        addons:
          apt:
            sources:
+             - ubuntu-toolchain-r-test
              - llvm-toolchain-trusty-5.0
              - george-edison55-precise-backports
            packages:
              - clang-5.0
+             - g++-7
              - cmake
              - cmake-data
              - build-essential

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 # test of travis ci for comblayer
-language: cpp
 matrix:
    include:
      - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,23 @@ matrix:
              - ubuntu-toolchain-r-test
              - george-edison55-precise-backports
            packages:
+             - g++-4.9
+             - cmake
+             - cmake-data
+             - build-essential
+             - libboost-regex-dev
+             - libgsl0-dev
+             - libboost-dev
+             - libboost-filesystem-dev
+       env:
+          - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+     - os: linux
+       addons:
+         apt:
+           sources:
+             - ubuntu-toolchain-r-test
+             - george-edison55-precise-backports
+           packages:
              - g++-5
              - cmake
              - cmake-data
@@ -89,11 +106,64 @@ matrix:
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
+     - os: linux
+       addons:
+         apt:
+           sources:
+             - llvm-toolchain-trusty-3.9
+             - george-edison55-precise-backports
+           packages:
+             - clang-3.9
+             - cmake
+             - cmake-data
+             - build-essential
+             - libboost-regex-dev
+             - libgsl0-dev
+             - libboost-dev
+             - libboost-filesystem-dev
+       env:
+          - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
+     - os: linux
+       addons:
+         apt:
+           sources:
+             - llvm-toolchain-trusty-4.0
+             - george-edison55-precise-backports
+           packages:
+             - clang-4.0
+             - cmake
+             - cmake-data
+             - build-essential
+             - libboost-regex-dev
+             - libgsl0-dev
+             - libboost-dev
+             - libboost-filesystem-dev
+       env:
+          - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+     - os: linux
+       addons:
+         apt:
+           sources:
+             - llvm-toolchain-trusty-5.0
+             - george-edison55-precise-backports
+           packages:
+             - clang-5.0
+             - cmake
+             - cmake-data
+             - build-essential
+             - libboost-regex-dev
+             - libgsl0-dev
+             - libboost-dev
+             - libboost-filesystem-dev
+       env:
+          - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
 before_install:
   - eval "${MATRIX_EVAL}" 
   - cmake -version
   - gcc --version
   - clang --version
+  - echo $CC
+  - echo $CXX 
 script:
   - ./CMake.pl -O -g++=$CXX
   - cmake ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,8 +96,8 @@ matrix:
              - llvm-toolchain-precise-3.8
              - george-edison55-precise-backports
            packages:
-             - clang-3.8
              - g++-7
+             - clang-3.8
              - cmake
              - cmake-data
              - build-essential
@@ -115,8 +115,8 @@ matrix:
              - llvm-toolchain-trusty-3.9
              - george-edison55-precise-backports
            packages:
-             - clang-3.9
              - g++-7
+             - clang-3.9
              - cmake
              - cmake-data
              - build-essential
@@ -134,8 +134,8 @@ matrix:
              - llvm-toolchain-trusty-4.0
              - george-edison55-precise-backports
            packages:
-             - clang-4.0
              - g++-7
+             - clang-4.0
              - cmake
              - cmake-data
              - build-essential
@@ -153,8 +153,8 @@ matrix:
              - llvm-toolchain-trusty-5.0
              - george-edison55-precise-backports
            packages:
-             - clang-5.0
              - g++-7
+             - clang-5.0
              - cmake
              - cmake-data
              - build-essential

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
              - cmake-data
              - libgsl0-dev
              - libboost-dev
+             - libboost-regex-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
@@ -31,6 +32,7 @@ matrix:
              - cmake-data
              - libgsl0-dev
              - libboost-dev
+             - libboost-regex-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
@@ -47,6 +49,7 @@ matrix:
              - cmake-data
              - libgsl0-dev
              - libboost-dev
+             - libboost-regex-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
@@ -63,6 +66,7 @@ matrix:
              - cmake-data
              - libgsl0-dev
              - libboost-dev
+             - libboost-regex-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
@@ -80,6 +84,7 @@ matrix:
              - cmake-data
              - libgsl0-dev
              - libboost-dev
+             - libboost-regex-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=clang-3.7 && CXX=clang++-3.7"
@@ -98,6 +103,7 @@ matrix:
              - cmake-data
              - libgsl0-dev
              - libboost-dev
+             - libboost-regex-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=clang-3.8 && CXX=clang++-3.8"
@@ -116,6 +122,7 @@ matrix:
              - cmake-data
              - libgsl0-dev
              - libboost-dev
+             - libboost-regex-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=clang-3.9 && CXX=clang++-3.9"
@@ -134,6 +141,7 @@ matrix:
              - cmake-data
              - libgsl0-dev
              - libboost-dev
+             - libboost-regex-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
@@ -152,6 +160,7 @@ matrix:
              - cmake-data
              - libgsl0-dev
              - libboost-dev
+             - libboost-regex-dev
              - libboost-filesystem-dev
        env:
           - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
@@ -164,8 +173,25 @@ script:
   - ./CMake.pl -O -g++=$CXX
   - cmake ./
   - make -j6
+  # unit test
   - ./testMain -1 -1 -1
-  - ./fullBuild -r fbtest 
+  # model quick tests
+  - ./fullBuild -r fb_test 
+  - ./ess -r ess_test
+  - ./bilbau -r bb_test
+  - ./sns -r sns_test
+  - ./reactor -r reactor_test
+  - ./muBeam -r mu_test
+  - ./pipe -r pipe_test
+  - ./photonMod2 -r photon_test
+  - ./singleItem -r single_test
+  - ./t1MarkII -r t1_test1
+  - ./t1Real -r t1_test2 
+  # model valid check
+  - ./fullBuild -r -validCheck 100000 fb_vtest
+ 
+  
+
 
 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+# test of travis ci for comblayer
+language: c
+os:
+  - linux
+compiler:
+  - gcc
+addons:
+  apt:
+    sources:
+      - george-edison55-backports
+    packages:
+      - cmake
+      - cmake-data
+      - gcc
+      - build-essential
+      - libboost-regex-dev
+      - libgsl-dev
+      - libboost-dev
+      - libboost-filesystem-dev
+before_install:
+  - cmake -version
+script:
+  - ./CMake.pl -O -g++=g++
+  - cmake ./
+  - make -j6
+  - fullBuild -r fbtest.o 
+  


### PR DESCRIPTION
added travis CI to comblayer 
build matrix of G++ versions 4.9,5 ,6  & 7
also clang 3.8, 3.7, 3.9, 4.0, & 5.0
runs the unit tests and some simple model tests, example of using validCheck also included

need to decide what  compiler versions actually want to support
currently everything fails, g++ fail to build and clang builds but then fail unit tests and fullbuild validCheck

but its a start and hopefully lead to more robust code