### PR TITLE
quadratic surface syntax fixed

### DIFF
--- a/System/geometry/Quadratic.cxx
+++ b/System/geometry/Quadratic.cxx
@@ -619,11 +619,11 @@ Quadratic::writePOVRay(std::ostream& OX) const
   
   OX<<"#declare s"<<getName()<<" = quadric{ \n"
     <<"<"
-    <<MW.Num(BaseEqn[0])<<" "<<MW.Num(BaseEqn[1])<<" "<<MW.Num(BaseEqn[2])
+    <<MW.Num(BaseEqn[0])<<","<<MW.Num(BaseEqn[1])<<","<<MW.Num(BaseEqn[2])
     <<">,<"
-    <<MW.Num(BaseEqn[3])<<" "<<MW.Num(BaseEqn[4])<<" "<<MW.Num(BaseEqn[5])
+    <<MW.Num(BaseEqn[3])<<","<<MW.Num(BaseEqn[4])<<","<<MW.Num(BaseEqn[5])
     <<">,<"
-    <<MW.Num(BaseEqn[6])<<" "<<MW.Num(BaseEqn[7])<<" "<<MW.Num(BaseEqn[8])
+    <<MW.Num(BaseEqn[6])<<","<<MW.Num(BaseEqn[7])<<","<<MW.Num(BaseEqn[8])
     <<">,"<<MW.Num(BaseEqn[9])<<"\n"<<" }"<<std::endl;  
   return;
 }


### PR DESCRIPTION
I believe the problem with povray was that we had to put commas in the quadratic surface definition. For some reason you can skip commas if the coordinates are positive, but you have to use them with negative coordinates.
Now it's fixed
![bifrost](https://user-images.githubusercontent.com/6359326/33215367-c2b38218-d12f-11e7-96f2-e7d747eb8e35.png)
