### PR TITLE
Minor fixes for povray

### DIFF
--- a/System/process/masterWrite.cxx
+++ b/System/process/masterWrite.cxx
@@ -153,6 +153,7 @@ masterWrite::NameNoDot(std::string V)
   */
 {
   std::replace(V.begin(),V.end(),'.','x');
+  std::replace(V.begin(),V.end(),'%','p');
   return V;
 }
 

--- a/src/SimPOVRay.cxx
+++ b/src/SimPOVRay.cxx
@@ -158,6 +158,11 @@ SimPOVRay::writeMaterial(std::ostream& OX) const
 
   DB.writePOVRay(OX);
   
+  // Overwrite textures by a user-provided file textures.inc
+  OX << "#if (file_exists(\"textures.inc\"))" << std::endl;
+  OX << "#include \"textures.inc\"" << std::endl;
+  OX << "#end"  << std::endl;
+
   return;
 }
   

--- a/src/SimPOVRay.cxx
+++ b/src/SimPOVRay.cxx
@@ -77,7 +77,6 @@ SimPOVRay::SimPOVRay() : Simulation()
   */
 {}
 
-
 SimPOVRay::SimPOVRay(const SimPOVRay& A) : Simulation(A)
  /*! 
    Copy constructor
@@ -99,8 +98,6 @@ SimPOVRay::operator=(const SimPOVRay& A)
     }
   return *this;
 }
-
-
 
 void
 SimPOVRay::writeCells(std::ostream& OX) const
@@ -158,9 +155,9 @@ SimPOVRay::writeMaterial(std::ostream& OX) const
 
   DB.writePOVRay(OX);
   
-  // Overwrite textures by a user-provided file textures.inc
-  OX << "#if (file_exists(\"textures.inc\"))" << std::endl;
-  OX << "#include \"textures.inc\"" << std::endl;
+  // Overwrite textures by a user-provided file
+  OX << "#if (file_exists(\"materials.inc\"))" << std::endl;
+  OX << "#include \"materials.inc\"" << std::endl;
   OX << "#end"  << std::endl;
 
   return;


### PR DESCRIPTION
Here are a couple of small fixes for povray:
- % symbols are allowed in the texture names (they are replaced with 'p')
- A user can redefine texture definitions by describing them in the file called 'materials.inc'