### PR TITLE
ESS sdef footprint is a 14x3.2 cm rectangle

### DIFF
--- a/System/source/SourceCreate.cxx
+++ b/System/source/SourceCreate.cxx
@@ -156,8 +156,8 @@ createESSSource(const FuncDataBase& Control,
   
   const double E=Control.EvalDefVar<double>("sdefEnergy",2000.0);
   const double yStart=Control.EvalDefVar<double>("sdefYPos",-30.0);
-  const double xRange=Control.EvalDefVar<double>("sdefWidth",8.0);
-  const double zRange=Control.EvalDefVar<double>("sdefHeight",3.0);
+  const double xRange=Control.EvalDefVar<double>("sdefWidth",14.0);
+  const double zRange=Control.EvalDefVar<double>("sdefHeight",3.2);
  
   ParabolicSource PSource("essSource");
   
@@ -166,6 +166,7 @@ createESSSource(const FuncDataBase& Control,
   PSource.setOffset(0,yStart,0);
   PSource.setRectangle(xRange,zRange);
   PSource.setPower(0.0);
+  PSource.setNPts(1,1);
   PSource.createAll(Control,FC,sideIndex);
   
   SDB.registerSource(PSource.getKeyName(),PSource);


### PR DESCRIPTION
The ESS sdef in the master branch is wrong again.
The shape is fine, but the size is wrong: now it's 8x3, but it must be 14x3.2.
This PR fixes it.