### PR TITLE
Misleading comments in MarkovProcess

### DIFF
--- a/System/weights/MarkovProcess.cxx
+++ b/System/weights/MarkovProcess.cxx
@@ -145,7 +145,7 @@ MarkovProcess::computeMatrix(const Simulation& System,
 			     const double r2Length,
 			     const double r2Power)
   /*!
-    Calculate the makov chain process
+    Calculate the Markov chain process
     \param System :: Simualation
     \param wSet :: WWG set for grid
     \param densityFactor :: Scaling factor for density

--- a/System/weightsInc/MarkovProcess.h
+++ b/System/weightsInc/MarkovProcess.h
@@ -25,18 +25,6 @@
 ///\file 
 
 class Simulation;
-namespace Geometry
-{
-  class Plane;
-}
-
-/*!
-  \namespace WeightSystem
-  \brief Adds a layer of shutters to the Target/Reflect/Moderatr
-  \author S. Ansell
-  \version 1.0
-  \date April 2009
-*/
 
 namespace WeightSystem
 {


### PR DESCRIPTION
Thisgit  PR just removes misleading comments in the MarkovProcess class.