### PR TITLE
POV-Rray material generation fixed

### DIFF
--- a/System/monte/Object.cxx
+++ b/System/monte/Object.cxx
@@ -1508,30 +1508,6 @@ Object::writePOVRay(std::ostream& OX) const
   return;
 }
 
-void
-Object::writePOVRaymat(std::ostream& OX) const
-  /*!
-    Write the object material assignment to a standard stream
-    in POVRay output format.
-    \param OX :: Output stream (required for multiple std::endl)
-  */
-{
-  ELog::RegMethod RegA("Object","writePOVRaymat");
-  if (!placehold)
-    {      
-      OX<<"POVRay dummy material string    ";
-      if (!MatN)   // are we really rendering vacuum ????
-	OX<<" VACUUM";
-      else
-	OX<<"    M"<<MatN;
-      
-      OX<<"    "<<FCUnit<<"_"<<ObjName<<std::endl;
-    }
-  
-  return;
-}
-
-  
 void 
 Object::writePHITS(std::ostream& OX) const
   /*!

--- a/System/monteInc/Object.h
+++ b/System/monteInc/Object.h
@@ -215,8 +215,6 @@ class Object
   void writeFLUKA(std::ostream&) const;    
   void writeFLUKAmat(std::ostream&) const;
   void writePOVRay(std::ostream&) const;    
-  void writePOVRaymat(std::ostream&) const;
-
 
   void checkPointers() const;
 

--- a/System/process/MainProcess.cxx
+++ b/System/process/MainProcess.cxx
@@ -663,7 +663,7 @@ buildFullSimPOVRay(SimPOVRay* SimPOVRayPtr,
   //   SimPOVRayPtr->setNoVariables();
 
   SimPOVRayPtr->prepareWrite();
-  SimPOVRayPtr->write(OName+".x");
+  SimPOVRayPtr->write(OName+".inc");
 
   return;
 }

--- a/System/process/masterWrite.cxx
+++ b/System/process/masterWrite.cxx
@@ -153,8 +153,9 @@ masterWrite::NameNoDot(std::string V)
     \return formated name
   */
 {
-  std::replace(V.begin(),V.end(),'.','x');
+  std::replace(V.begin(),V.end(),'.','d');
   std::replace(V.begin(),V.end(),'%','p');
+  std::replace(V.begin(),V.end(),'#','h');
   return V;
 }
 

--- a/povray/materials.inc
+++ b/povray/materials.inc
@@ -1,0 +1,25 @@
+// These are user-defined material definitions for POV-Ray which overwrite
+// automatically generated colours.
+// Feel free to edit this file according to your taste.
+
+#declare matAluminium    = texture { pigment{color rgb <0.89, 0.91, 0.91> }};
+#declare matB4C          = texture { pigment{color rgb <0.1, 0.1, 0.1> }};
+#declare matConcrete     = texture {T_Wood8};
+
+// http://news.povray.org/povray.general/thread/%3C35D92C3C.AD869B36%40pacbell.net%3E/
+#declare matHDConcrete =
+   texture { pigment { granite turbulence 1.5 color_map {
+    [0  .25 color White color Gray75] [.25  .5 color White color Gray75]
+    [.5 .75 color White color Gray75] [.75 1.1 color White color Gray75]}}
+    finish { ambient 0.2 diffuse 0.3 crand 0.03 reflection 0 } normal {
+    dents .5 scale .5 }}
+
+#declare matSkanskaConcrete =
+   texture { pigment { granite turbulence 1.5 color_map {
+    [0  .25 color White color Gray95] [.25  .5 color White color White]
+    [.5 .75 color White color White] [.75 1.1 color White color Gray85]}}
+    finish { ambient 0.2 diffuse 0.3 crand 0.003 reflection 0 } normal {
+    dents .5 scale .5 }}
+
+#declare matLead         = texture { pigment{color rgb <0.61, 0.59, 0.54> }};
+#declare matStainless304 = texture { Silver_Metal };

--- a/src/SimPOVRay.cxx
+++ b/src/SimPOVRay.cxx
@@ -154,8 +154,8 @@ SimPOVRay::writeMaterial(std::ostream& OX) const
   DB.writePOVRay(OX);
   
   // Overwrite textures by a user-provided file
-  OX << "#if (file_exists(\"materials.inc\"))" << std::endl;
-  OX << "#include \"materials.inc\"" << std::endl;
+  OX << "#if (file_exists(\"povray/materials.inc\"))" << std::endl;
+  OX << "#include \"povray/materials.inc\"" << std::endl;
   OX << "#end"  << std::endl;
 
   return;

--- a/src/SimPOVRay.cxx
+++ b/src/SimPOVRay.cxx
@@ -158,6 +158,10 @@ SimPOVRay::writeMaterial(std::ostream& OX) const
   OX << "#include \"povray/materials.inc\"" << std::endl;
   OX << "#end"  << std::endl;
 
+  OX << "#if (file_exists(\"materials.inc\"))" << std::endl;
+  OX << "#include \"materials.inc\"" << std::endl;
+  OX << "#end"  << std::endl;
+
   return;
 }
   

--- a/src/SimPOVRay.cxx
+++ b/src/SimPOVRay.cxx
@@ -144,10 +144,6 @@ SimPOVRay::writeMaterial(std::ostream& OX) const
 {
   ELog::RegMethod RegA("SimPOVRay","writeMaterial");
 
-  // WRITE OUT ASSIGNMENT:
-  for(const OTYPE::value_type& mp : OList)
-    mp.second->writePOVRaymat(OX);
-    
   ModelSupport::DBMaterial& DB=ModelSupport::DBMaterial::Instance();  
   DB.resetActive();
 


### PR DESCRIPTION
This PR removes the `Object::writePOVRaymat` method, adds `povray/materials.inc` with user-defined material descriptions and sets extension of POV-Ray files to `.inc`.