### PR TITLE
Plate -> Cap

### DIFF
--- a/Model/MaxIV/commonBeam/GrateMonoBox.cxx
+++ b/Model/MaxIV/commonBeam/GrateMonoBox.cxx
@@ -165,8 +165,8 @@ GrateMonoBox::populate(const FuncDataBase& Control)
   
   const size_t NPorts=Control.EvalVar<size_t>(keyName+"NPorts");
   const std::string portBase=keyName+"Port";
-  double L,R,W,FR,FT,PT;
-  int PMat;
+  double L,R,W,FR,FT,CT;
+  int capMat;
   int OFlag;
   for(size_t i=0;i<NPorts;i++)
     {
@@ -182,16 +182,16 @@ GrateMonoBox::populate(const FuncDataBase& Control)
       W=Control.EvalPair<double>(portName,portBase,"Wall");
       FR=Control.EvalPair<double>(portName,portBase,"FlangeRadius");
       FT=Control.EvalPair<double>(portName,portBase,"FlangeLength");
-      PT=Control.EvalDefPair<double>(portName,portBase,"PlateThick",0.0);
-      PMat=ModelSupport::EvalDefMat<int>
-	(Control,portName+"PlateMat",portBase+"PlateMat",wallMat);
+      CT=Control.EvalDefPair<double>(portName,portBase,"CapThick",0.0);
+      capMat=ModelSupport::EvalDefMat<int>
+	(Control,portName+"CapMat",portBase+"CapMat",wallMat);
 
       OFlag=Control.EvalDefVar<int>(portName+"OuterVoid",0);
 
       if (OFlag) windowPort.setWrapVolume();
       windowPort.setMain(L,R,W);
       windowPort.setFlange(FR,FT);
-      windowPort.setCoverPlate(PT,PMat);
+      windowPort.setCoverPlate(CT,capMat);
       windowPort.setMaterial(voidMat,wallMat);
 
       PCentre.push_back(Centre);

--- a/Model/MaxIV/species/TankMonoVessel.cxx
+++ b/Model/MaxIV/species/TankMonoVessel.cxx
@@ -177,8 +177,8 @@ TankMonoVessel::populate(const FuncDataBase& Control)
   
   const size_t NPorts=Control.EvalVar<size_t>(keyName+"NPorts");
   const std::string portBase=keyName+"Port";
-  double L,R,W,FR,FT,PT;
-  int PMat;
+  double L,R,W,FR,FT,CT;
+  int capMat;
   int OFlag;
   for(size_t i=0;i<NPorts;i++)
     {
@@ -194,16 +194,16 @@ TankMonoVessel::populate(const FuncDataBase& Control)
       W=Control.EvalPair<double>(portName,portBase,"Wall");
       FR=Control.EvalPair<double>(portName,portBase,"FlangeRadius");
       FT=Control.EvalPair<double>(portName,portBase,"FlangeLength");
-      PT=Control.EvalDefPair<double>(portName,portBase,"PlateThick",0.0);
-      PMat=ModelSupport::EvalDefMat<int>
-	(Control,portName+"PlateMat",portBase+"PlateMat",wallMat);
+      CT=Control.EvalDefPair<double>(portName,portBase,"CapThick",0.0);
+      capMat=ModelSupport::EvalDefMat<int>
+	(Control,portName+"CapMat",portBase+"CapMat",wallMat);
 
       OFlag=Control.EvalDefVar<int>(portName+"OuterVoid",0);
 
       if (OFlag) windowPort.setWrapVolume();
       windowPort.setMain(L,R,W);
       windowPort.setFlange(FR,FT);
-      windowPort.setCoverPlate(PT,PMat);
+      windowPort.setCoverPlate(CT,capMat);
       windowPort.setMaterial(voidMat,wallMat);
 
       PCentre.push_back(Centre);

--- a/System/construct/PipeTube.cxx
+++ b/System/construct/PipeTube.cxx
@@ -138,10 +138,10 @@ PipeTube::populate(const FuncDataBase& Control)
   flangeBLength=Control.EvalPair<double>(keyName+"FlangeBLength",
 					 keyName+"FlangeLength");
 
-  flangeACap=Control.EvalDefPair<double>(keyName+"FlangeACap",
-					 keyName+"FlangeCap",0.0);
-  flangeBCap=Control.EvalDefPair<double>(keyName+"FlangeBCap",
-					 keyName+"FlangeCap",0.0);
+  flangeACapThick=Control.EvalDefPair<double>(keyName+"FlangeACapThick",
+					 keyName+"FlangeCapThick",0.0);
+  flangeBCapThick=Control.EvalDefPair<double>(keyName+"FlangeBCapThick",
+					 keyName+"FlangeCapThick",0.0);
   
   voidMat=ModelSupport::EvalDefMat<int>(Control,keyName+"VoidMat",0);
   wallMat=ModelSupport::EvalMat<int>(Control,keyName+"WallMat");
@@ -238,14 +238,14 @@ PipeTube::createSurfaces()
   ModelSupport::buildCylinder(SMap,buildIndex+17,Origin,Y,radius+wallThick);
 
   ModelSupport::buildPlane(SMap,buildIndex+101,
-			   Origin-Y*(length/2.0-(flangeALength+flangeACap)),Y);
+			   Origin-Y*(length/2.0-(flangeALength+flangeACapThick)),Y);
   ModelSupport::buildPlane(SMap,buildIndex+102,
-			   Origin+Y*(length/2.0-(flangeBLength+flangeBCap)),Y);
+			   Origin+Y*(length/2.0-(flangeBLength+flangeBCapThick)),Y);
 
   ModelSupport::buildPlane(SMap,buildIndex+201,
-			   Origin-Y*(length/2.0-flangeACap),Y);
+			   Origin-Y*(length/2.0-flangeACapThick),Y);
   ModelSupport::buildPlane(SMap,buildIndex+202,
-			   Origin+Y*(length/2.0-flangeBCap),Y);
+			   Origin+Y*(length/2.0-flangeBCapThick),Y);
 
   // flange:
   ModelSupport::buildCylinder(SMap,buildIndex+107,Origin,Y,flangeARadius);
@@ -267,10 +267,10 @@ PipeTube::createObjects(Simulation& System)
   const std::string backSurf(backRule());
 
   const std::string frontVoidSurf=
-    (flangeACap<Geometry::zeroTol) ? frontSurf :
+    (flangeACapThick<Geometry::zeroTol) ? frontSurf :
     ModelSupport::getComposite(SMap,buildIndex," 201 ");
   const std::string backVoidSurf=
-    (flangeBCap<Geometry::zeroTol) ? backSurf :
+    (flangeBCapThick<Geometry::zeroTol) ? backSurf :
     ModelSupport::getComposite(SMap,buildIndex," -202 ");
   
   
@@ -291,13 +291,13 @@ PipeTube::createObjects(Simulation& System)
   makeCell("BackFlange",System,cellIndex++,wallMat,0.0,Out+backVoidSurf);
 
 
-  if (flangeACap>Geometry::zeroTol)
+  if (flangeACapThick>Geometry::zeroTol)
     {
       Out=ModelSupport::getComposite(SMap,buildIndex," -201 -107 ");
       makeCell("FrontCap",System,cellIndex++,capMat,0.0,Out+frontSurf);	    
     }
   
-  if (flangeBCap>Geometry::zeroTol)
+  if (flangeBCapThick>Geometry::zeroTol)
     {
       Out=ModelSupport::getComposite(SMap,buildIndex," 202 -207 ");
       makeCell("BackCap",System,cellIndex++,capMat,0.0,Out+backSurf);

--- a/System/construct/PipeTube.cxx
+++ b/System/construct/PipeTube.cxx
@@ -152,8 +152,8 @@ PipeTube::populate(const FuncDataBase& Control)
     
   const size_t NPorts=Control.EvalVar<size_t>(keyName+"NPorts");
   const std::string portBase=keyName+"Port";
-  double L,R,W,FR,FT,PT;
-  int PMat;
+  double L,R,W,FR,FT,CT;
+  int capMat;
   int OFlag;
   for(size_t i=0;i<NPorts;i++)
     {
@@ -169,16 +169,16 @@ PipeTube::populate(const FuncDataBase& Control)
       W=Control.EvalPair<double>(portName,portBase,"Wall");
       FR=Control.EvalPair<double>(portName,portBase,"FlangeRadius");
       FT=Control.EvalPair<double>(portName,portBase,"FlangeLength");
-      PT=Control.EvalDefPair<double>(portName,portBase,"PlateThick",0.0);
-      PMat=ModelSupport::EvalDefMat<int>
-	(Control,portName+"PlateMat",portBase+"PlateMat",wallMat);
+      CT=Control.EvalDefPair<double>(portName,portBase,"CapThick",0.0);
+      capMat=ModelSupport::EvalDefMat<int>
+	(Control,portName+"CapMat",portBase+"CapMat",wallMat);
 
       OFlag=Control.EvalDefVar<int>(portName+"OuterVoid",0);
 
       if (OFlag) windowPort->setWrapVolume();
       windowPort->setMain(L,R,W);
       windowPort->setFlange(FR,FT);
-      windowPort->setCoverPlate(PT,PMat);
+      windowPort->setCoverPlate(CT,capMat);
       windowPort->setMaterial(voidMat,wallMat);
 
       PCentre.push_back(Centre);

--- a/System/constructInc/PipeTube.h
+++ b/System/constructInc/PipeTube.h
@@ -52,8 +52,8 @@ class PipeTube :
   double flangeALength;        ///< Joining Flange length
   double flangeBRadius;        ///< Joining Flange radius
   double flangeBLength;        ///< Joining Flange length
-  double flangeACap;           ///< Thickness of Flange cap if present
-  double flangeBCap;           ///< Thickness of Flange cap if present
+  double flangeACapThick;           ///< Thickness of Flange cap if present
+  double flangeBCapThick;           ///< Thickness of Flange cap if present
   
   int voidMat;                ///< void material
   int wallMat;                ///< Fe material layer

--- a/System/constructInc/portItem.h
+++ b/System/constructInc/portItem.h
@@ -64,11 +64,11 @@ class portItem :
   double wall;               ///< wall thick
   double flangeRadius;       ///< flange radius
   double flangeLength;       ///< flange thick(length)
-  double plateThick;         ///< Plate on flange [if thick>0]
+  double capThick;           ///< Plate on flange [if thick>0]
 
   int voidMat;               ///< Void material
   int wallMat;               ///< Wall material
-  int plateMat;              ///< plate Material
+  int capMat;                ///< plate Material
 
   std::set<int> outerCell;   ///< Extra cell to add outer to
   std::string refComp;       ///< Name of reference object

--- a/System/constructVar/PipeTubeGenerator.cxx
+++ b/System/constructVar/PipeTubeGenerator.cxx
@@ -252,8 +252,8 @@ PipeTubeGenerator::generateTube(FuncDataBase& Control,
   Control.addVariable(keyName+"FlangeBRadius",flangeBRadius);
   Control.addVariable(keyName+"FlangeBLength",flangeBLen);
 
-  Control.addVariable(keyName+"FlangeACap",ACap);
-  Control.addVariable(keyName+"FlangeBCap",BCap);
+  Control.addVariable(keyName+"FlangeACapThick",ACap);
+  Control.addVariable(keyName+"FlangeBCapThick",BCap);
   Control.addVariable(keyName+"FlangeCapMat",capMat);
 
   Control.addVariable(keyName+"VoidMat",voidMat);

--- a/System/constructVar/PortItemGenerator.cxx
+++ b/System/constructVar/PortItemGenerator.cxx
@@ -61,9 +61,9 @@ namespace setVariable
 PortItemGenerator::PortItemGenerator() :
   length(12.0),radius(5.0),wallThick(0.5),
   flangeLen(1.0),flangeRadius(1.0),
-  plateThick(0.0),
+  capThick(0.0),
   wallMat("Stainless304"),
-  plateMat("Aluminium"),
+  capMat("Aluminium"),
   outerVoid(1)
   /*!
     Constructor and defaults
@@ -73,8 +73,8 @@ PortItemGenerator::PortItemGenerator() :
 PortItemGenerator::PortItemGenerator(const PortItemGenerator& A) : 
   length(A.length),radius(A.radius),wallThick(A.wallThick),
   flangeLen(A.flangeLen),flangeRadius(A.flangeRadius),
-  plateThick(A.plateThick),wallMat(A.wallMat),
-  plateMat(A.plateMat),outerVoid(A.outerVoid)
+  capThick(A.capThick),wallMat(A.wallMat),
+  capMat(A.capMat),outerVoid(A.outerVoid)
   /*!
     Copy constructor
     \param A :: PortItemGenerator to copy
@@ -96,9 +96,9 @@ PortItemGenerator::operator=(const PortItemGenerator& A)
       wallThick=A.wallThick;
       flangeLen=A.flangeLen;
       flangeRadius=A.flangeRadius;
-      plateThick=A.plateThick;
+      capThick=A.capThick;
       wallMat=A.wallMat;
-      plateMat=A.plateMat;
+      capMat=A.capMat;
       outerVoid=A.outerVoid;
     }
   return *this;
@@ -124,7 +124,7 @@ PortItemGenerator::setCF(const double L)
   wallThick=CF::wallThick;
   flangeLen=CF::flangeLength;
   flangeRadius=CF::flangeRadius;
-  plateThick=CF::flangeLength;
+  capThick=CF::flangeLength;
   
   return;
 }
@@ -167,8 +167,8 @@ PortItemGenerator::setPlate(const double T,const std::string& PM)
     \param PM :: material for plate
    */
 {
-  plateThick=T;
-  plateMat=PM;
+  capThick=T;
+  capMat=PM;
   return;
 }
   
@@ -194,14 +194,14 @@ PortItemGenerator::generatePort(FuncDataBase& Control,
 
   Control.addVariable(keyName+"FlangeRadius",flangeRadius);
   Control.addVariable(keyName+"FlangeLength",flangeLen);
-  Control.addVariable(keyName+"PlateThick",plateThick);
+  Control.addVariable(keyName+"CapThick",capThick);
 
   Control.addVariable(keyName+"Centre",C);
   Control.addVariable(keyName+"Axis",A.unit());
 
   Control.addVariable(keyName+"OuterVoid",static_cast<int>(outerVoid));
   Control.addVariable(keyName+"WallMat",wallMat);
-  Control.addVariable(keyName+"PlateMat",plateMat);
+  Control.addVariable(keyName+"CapMat",capMat);
   
   return;
 

--- a/System/constructVarInc/PortItemGenerator.h
+++ b/System/constructVarInc/PortItemGenerator.h
@@ -45,10 +45,10 @@ class PortItemGenerator
   
   double flangeLen;          ///< Flange length
   double flangeRadius;       ///< Flange radius
-  double plateThick;         ///< Plate thickness
+  double capThick;         ///< Plate thickness
 
   std::string wallMat;       ///< tube wall material
-  std::string plateMat;      ///< cover plate material
+  std::string capMat;      ///< cover plate material
   
   bool outerVoid;            ///< Construct outer void
   


### PR DESCRIPTION
This PR renames the variables for `PipeTube` and `portItem` classes:

- `Cap`  🡒`CapThick`
- `PlateThick` 🡒 `CapThick`
- `PlateMat` 🡒 `CapMat`

One must be careful with this change because all these variables are set by default to zero and therefore if the system does not find the original name it uses zero without complains. Therefore I have also manually checked the models:
This renaming does not change the following MAX IV models: `COSAXS`, `FLEXPES`, `MAXPEEM`, `SPECIES`, `R3RING`, `R1RING`, and `RING1`
I could not check the `BALDER` `FORMAX` `MICROMAX` models because I could not build them.