### PR TITLE
typo: min -> max in Object::setMagStep

### DIFF
--- a/System/monte/Object.cxx
+++ b/System/monte/Object.cxx
@@ -237,8 +237,8 @@ Object::setMagStep(const double minV,const double maxV)
   ELog::RegMethod RegA("Object","setMagStep");
 
   magMinStep=std::min(minV,maxV);
-  magMaxStep=std::min(minV,maxV);  
-  
+  magMaxStep=std::max(minV,maxV);
+
   return;
 }
 


### PR DESCRIPTION
A small typo fixed, otherwise magMaxStep is wrong.
Still missing: the STEPSIZE value should be set only for requested cells.