### PR TITLE
VacuumPipe: FlangeMat variable added

### DIFF
--- a/System/construct/VacuumPipe.cxx
+++ b/System/construct/VacuumPipe.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   construct/VacuumPipe.cxx
  *
  * Copyright (c) 2004-2020 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -66,7 +66,7 @@
 #include "ModelSupport.h"
 #include "MaterialSupport.h"
 #include "generateSurf.h"
-#include "LinkUnit.h"  
+#include "LinkUnit.h"
 #include "FixedComp.h"
 #include "FixedOffset.h"
 #include "ContainedComp.h"
@@ -84,7 +84,7 @@
 namespace constructSystem
 {
 
-VacuumPipe::VacuumPipe(const std::string& Key) : 
+VacuumPipe::VacuumPipe(const std::string& Key) :
   attachSystem::FixedOffset(Key,11),
   attachSystem::ContainedComp(),attachSystem::CellMap(),
   attachSystem::SurfMap(),attachSystem::FrontBackCut(),
@@ -99,7 +99,7 @@ VacuumPipe::VacuumPipe(const std::string& Key) :
   FixedComp::nameSideIndex(6,"midPoint");
 }
 
-VacuumPipe::VacuumPipe(const VacuumPipe& A) : 
+VacuumPipe::VacuumPipe(const VacuumPipe& A) :
   attachSystem::FixedOffset(A),attachSystem::ContainedComp(A),
   attachSystem::CellMap(A),attachSystem::SurfMap(A),
   attachSystem::FrontBackCut(A),
@@ -107,13 +107,15 @@ VacuumPipe::VacuumPipe(const VacuumPipe& A) :
   FPt(A.FPt),FAxis(A.FAxis),backJoin(A.backJoin),
   BPt(A.BPt),BAxis(A.BAxis),radius(A.radius),height(A.height),
   width(A.width),length(A.length),feThick(A.feThick),
+  claddingThick(A.claddingThick),
   flangeARadius(A.flangeARadius),flangeAHeight(A.flangeAHeight),
   flangeAWidth(A.flangeAWidth),flangeALength(A.flangeALength),
   flangeBRadius(A.flangeBRadius),flangeBHeight(A.flangeBHeight),
   flangeBWidth(A.flangeBWidth),flangeBLength(A.flangeBLength),
   activeWindow(A.activeWindow),windowFront(A.windowFront),
   windowBack(A.windowBack),voidMat(A.voidMat),
-  feMat(A.feMat),nDivision(A.nDivision)
+  feMat(A.feMat),claddingMat(A.claddingMat),flangeMat(A.flangeMat),
+  nDivision(A.nDivision)
   /*!
     Copy constructor
     \param A :: VacuumPipe to copy
@@ -162,12 +164,13 @@ VacuumPipe::operator=(const VacuumPipe& A)
       voidMat=A.voidMat;
       feMat=A.feMat;
       claddingMat=A.claddingMat;
+      flangeMat=A.flangeMat;
       nDivision=A.nDivision;
     }
   return *this;
 }
 
-VacuumPipe::~VacuumPipe() 
+VacuumPipe::~VacuumPipe()
   /*!
     Destructor
   */
@@ -181,7 +184,7 @@ VacuumPipe::populate(const FuncDataBase& Control)
   */
 {
   ELog::RegMethod RegA("VacuumPipe","populate");
-  
+
   FixedOffset::populate(Control);
 
   // Void + Fe special:
@@ -192,7 +195,7 @@ VacuumPipe::populate(const FuncDataBase& Control)
   if (radius<0.0 && (width<0.0 || height<0.0))
     throw ColErr::EmptyContainer
       ("Pipe:["+keyName+"] has neither Radius or Height/Width");
-  
+
   length=Control.EvalVar<double>(keyName+"Length");
 
   feThick=Control.EvalVar<double>(keyName+"FeThick");
@@ -201,7 +204,7 @@ VacuumPipe::populate(const FuncDataBase& Control)
   const double fR=Control.EvalDefVar<double>(keyName+"FlangeRadius",-1.0);
   const double fH=Control.EvalDefVar<double>(keyName+"FlangeHeight",-1.0);
   const double fW=Control.EvalDefVar<double>(keyName+"FlangeWidth",-1.0);
-  
+
   flangeARadius=Control.EvalDefVar<double>(keyName+"FlangeFrontRadius",fR);
   flangeAHeight=Control.EvalDefVar<double>(keyName+"FlangeFrontHeight",fH);
   flangeAWidth=Control.EvalDefVar<double>(keyName+"FlangeFrontWidth",fW);
@@ -223,7 +226,7 @@ VacuumPipe::populate(const FuncDataBase& Control)
 
   // note 1 ==> front : 2 => back  3 both
   activeWindow=Control.EvalDefVar<int>(keyName+"WindowActive",0);
-  
+
   windowFront.thick=Control.EvalDefPair<double>
     (keyName+"WindowFrontThick",keyName+"WindowThick",0.0);
   windowFront.radius=Control.EvalDefPair<double>
@@ -235,7 +238,7 @@ VacuumPipe::populate(const FuncDataBase& Control)
   windowFront.mat=ModelSupport::EvalDefMat<int>
     (Control,keyName+"WindowFrontMat",keyName+"WindowMat",0);
 
-    
+
   windowBack.thick=Control.EvalDefPair<double>
     (keyName+"WindowBackThick",keyName+"WindowThick",0.0);
   windowBack.radius=Control.EvalDefPair<double>
@@ -258,7 +261,7 @@ VacuumPipe::populate(const FuncDataBase& Control)
       if (windowFront.radius<Geometry::zeroTol &&
 	  (windowFront.width<Geometry::zeroTol || windowFront.height<Geometry::zeroTol))
 	throw ColErr::EmptyContainer("Pipe:["+keyName+"] has neither "
-				     "windowFront:Radius or Height/Width");	
+				     "windowFront:Radius or Height/Width");
 
       if (windowFront.radius>Geometry::zeroTol &&
 	  windowFront.radius+Geometry::zeroTol>flangeARadius)
@@ -270,18 +273,19 @@ VacuumPipe::populate(const FuncDataBase& Control)
       if (windowBack.radius<Geometry::zeroTol &&
 	  (windowBack.width<Geometry::zeroTol || windowBack.height<Geometry::zeroTol))
 	throw ColErr::EmptyContainer("Pipe:["+keyName+"] has neither "
-				     "windowBack:Radius or Height/Width");	
+				     "windowBack:Radius or Height/Width");
 
       if (windowBack.radius>Geometry::zeroTol &&
 	  windowBack.radius+Geometry::zeroTol>flangeBRadius)
 	throw ColErr::SizeError<double>
 	  (windowBack.radius,flangeBRadius,"Pipe:["+keyName+"] windowBack.Radius/flangeBRadius");
     }
-			    
-			    
+
+
   voidMat=ModelSupport::EvalDefMat<int>(Control,keyName+"VoidMat",0);
   feMat=ModelSupport::EvalMat<int>(Control,keyName+"FeMat");
   claddingMat=ModelSupport::EvalDefMat<int>(Control,keyName+"CladdingMat",0);
+  flangeMat=ModelSupport::EvalDefMat<int>(Control,keyName+"FlangeMat",feMat);
 
   nDivision=Control.EvalDefVar<size_t>(keyName+"NDivision",0);
   return;
@@ -340,7 +344,7 @@ VacuumPipe::applyActiveFrontBack()
     }
   return;
 }
-  
+
 
 void
 VacuumPipe::createSurfaces()
@@ -349,7 +353,7 @@ VacuumPipe::createSurfaces()
   */
 {
   ELog::RegMethod RegA("VacuumPipe","createSurfaces");
-  
+
   if (!isActive("front"))
     {
       ModelSupport::buildPlane(SMap,buildIndex+1,Origin-Y*(length/2.0),Y);
@@ -360,7 +364,7 @@ VacuumPipe::createSurfaces()
       ModelSupport::buildPlane(SMap,buildIndex+2,Origin+Y*(length/2.0),Y);
       ExternalCut::setCutSurf("back",-SMap.realSurf(buildIndex+2));
     }
-  
+
   // Front Inner void
   getShiftedFront(SMap,buildIndex+101,1,Y,flangeALength);
   if (activeWindow & 1)
@@ -393,7 +397,7 @@ VacuumPipe::createSurfaces()
       addSurf("BackWindow",buildIndex+1101);
       addSurf("BackWindow",buildIndex+1102);
     }
-  
+
   // MAIN SURFACES:
   if (radius>Geometry::zeroTol)
     {
@@ -401,7 +405,7 @@ VacuumPipe::createSurfaces()
       ModelSupport::buildCylinder(SMap,buildIndex+17,Origin,Y,radius+feThick);
       ModelSupport::buildCylinder(SMap,buildIndex+27,Origin,
 				  Y,radius+feThick+claddingThick);
-      addSurf("OuterRadius",SMap.realSurf(buildIndex+27));	    
+      addSurf("OuterRadius",SMap.realSurf(buildIndex+27));
     }
   else
     {
@@ -450,7 +454,7 @@ VacuumPipe::createSurfaces()
       ModelSupport::buildPlane(SMap,buildIndex+206,Origin+Z*(flangeBHeight/2.0),Z);
     }
 
-  // FRONT WINDOW SURFACES:  
+  // FRONT WINDOW SURFACES:
   if (activeWindow & 1)
     {
       if (windowFront.radius>0.0)
@@ -469,7 +473,7 @@ VacuumPipe::createSurfaces()
 	}
     }
 
-  // FRONT WINDOW SURFACES:  
+  // FRONT WINDOW SURFACES:
   if (activeWindow & 2)
     {
       if (windowBack.radius>Geometry::zeroTol)
@@ -487,7 +491,7 @@ VacuumPipe::createSurfaces()
                                    Origin+Z*(windowBack.height/2.0),Z);
 	}
     }
-  
+
   return;
 }
 
@@ -501,14 +505,14 @@ VacuumPipe::createObjects(Simulation& System)
   ELog::RegMethod RegA("VacuumPipe","createObjects");
 
   std::string Out;
-  
+
   const std::string frontStr=getRuleStr("front");
   const std::string backStr=getRuleStr("back");
 
   std::string windowFrontExclude;
   std::string windowBackExclude;
   if (activeWindow & 1)      // FRONT
-    { 
+    {
       Out=ModelSupport::getSetComposite
 	(SMap,buildIndex,"-1007 1003 -1004 1005 -1006 1001 -1002 ");
       System.addCell(MonteCarlo::Object(cellIndex++,windowFront.mat,0.0,
@@ -520,7 +524,7 @@ VacuumPipe::createObjects(Simulation& System)
       windowFrontExclude=WHR.display();
     }
   if (activeWindow & 2)
-    { 
+    {
       Out=ModelSupport::getSetComposite(SMap,buildIndex,"-1107 1103 -1104 1105 -1106 1102 -1101 ");
       System.addCell(MonteCarlo::Object(cellIndex++,windowBack.mat,0.0,
 				       Out+backBridgeRule()));
@@ -541,7 +545,7 @@ VacuumPipe::createObjects(Simulation& System)
 
   Out=ModelSupport::getSetComposite(SMap,buildIndex," -17 13 -14 15 -16");
   HeadRule WallLayer(Out);
-  
+
   Out=ModelSupport::getSetComposite(SMap,buildIndex," -27 23 -24 25 -26");
   HeadRule CladdingLayer(Out);
 
@@ -559,19 +563,19 @@ VacuumPipe::createObjects(Simulation& System)
       addCell("Cladding",cellIndex-1);
     }
 
-  // FLANGE: 107 OR 103-106 valid 
+  // FLANGE: 107 OR 103-106 valid
   Out=ModelSupport::getSetComposite(SMap,buildIndex," -101 -107 103 -104 105 -106 ");
   Out+=InnerVoid.display();
-  System.addCell(MonteCarlo::Object(cellIndex++,feMat,0.0,Out+
+  System.addCell(MonteCarlo::Object(cellIndex++,flangeMat,0.0,Out+
 				   frontStr+windowFrontExclude));
   addCell("Steel",cellIndex-1);
 
-  // FLANGE: 207 OR 203-206 valid 
+  // FLANGE: 207 OR 203-206 valid
   Out=ModelSupport::getSetComposite(SMap,buildIndex,"102 -207 203 -204 205 -106 ");
 
   Out+=InnerVoid.display()+backStr+windowBackExclude;
-	    
-  System.addCell(MonteCarlo::Object(cellIndex++,feMat,0.0,Out));
+
+  System.addCell(MonteCarlo::Object(cellIndex++,flangeMat,0.0,Out));
   addCell("Steel",cellIndex-1);
 
   // outer boundary [flange front]
@@ -603,7 +607,7 @@ VacuumPipe::createDivision(Simulation& System)
     {
       ModelSupport::surfDivide DA;
       DA.setBasicSplit(nDivision,feMat);
-      
+
       DA.init();
       DA.setCellN(getCell("MainSteel"));
       DA.setOutNum(cellIndex,buildIndex+1000);
@@ -615,10 +619,10 @@ VacuumPipe::createDivision(Simulation& System)
       removeCell("MainSteel");
       addCells("MainSteel",DA.getCells());
     }
-   
+
   return;
 }
-  
+
 void
 VacuumPipe::createLinks()
   /*!
@@ -670,7 +674,7 @@ VacuumPipe::createLinks()
       FixedComp::setLinkSurf(7,-SMap.realSurf(buildIndex+15));
       FixedComp::setLinkSurf(8,SMap.realSurf(buildIndex+16));
     }
-  
+
   // MID Point: [NO SURF]
   const Geometry::Vec3D midPt=
     (getLinkPt(1)+getLinkPt(2))/2.0;
@@ -680,7 +684,7 @@ VacuumPipe::createLinks()
     {
       FixedComp::setConnect(9,Origin-Z*flangeARadius,-Z);
       FixedComp::setConnect(10,Origin+Z*flangeARadius,Z);
-      
+
       FixedComp::setLinkSurf(9,SMap.realSurf(buildIndex+107));
       FixedComp::setLinkSurf(10,SMap.realSurf(buildIndex+107));
     }
@@ -695,37 +699,37 @@ VacuumPipe::createLinks()
 
   return;
 }
-  
+
 void
 VacuumPipe::setJoinFront(const attachSystem::FixedComp& FC,
 			 const long int sideIndex)
   /*!
     Set front surface
-    \param FC :: FixedComponent 
+    \param FC :: FixedComponent
     \param sideIndex ::  Direction to link
    */
 {
   ELog::RegMethod RegA("VacuumPipe","setJoinFront");
 
-  
+
   FrontBackCut::setFront(FC,sideIndex);
   frontJoin=1;
   FPt=FC.getLinkPt(sideIndex);
   FAxis=FC.getLinkAxis(sideIndex);
   return;
 }
-  
+
 void
 VacuumPipe::setJoinBack(const attachSystem::FixedComp& FC,
 			const long int sideIndex)
   /*!
     Set Back surface
-    \param FC :: FixedComponent 
+    \param FC :: FixedComponent
     \param sideIndex ::  Direction to link
    */
 {
   ELog::RegMethod RegA("VacuumPipe","setJoinBack");
-  
+
   FrontBackCut::setBack(FC,sideIndex);
   backJoin=1;
   BPt=FC.getLinkPt(sideIndex);
@@ -733,7 +737,7 @@ VacuumPipe::setJoinBack(const attachSystem::FixedComp& FC,
 
   return;
 }
-  
+
 void
 VacuumPipe::createAll(Simulation& System,
 		      const attachSystem::FixedComp& FC,
@@ -749,13 +753,13 @@ VacuumPipe::createAll(Simulation& System,
 
   populate(System.getDataBase());
   createUnitVector(FC,FIndex);
-  createSurfaces();    
+  createSurfaces();
   createObjects(System);
   createLinks();
   createDivision(System);
-  insertObjects(System);   
-  
+  insertObjects(System);
+
   return;
 }
-  
+
 }  // NAMESPACE constructSystem

--- a/System/constructInc/VacuumPipe.h
+++ b/System/constructInc/VacuumPipe.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   constructInc/VacuumPipe.h
  *
  * Copyright (c) 2004-2019 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef constructSystem_VacuumPipe_h
@@ -42,13 +42,13 @@ struct windowInfo
   double width;           ///< Window Width
   int mat;                ///< Material
 };
-  
+
 /*!
   \class VacuumPipe
   \version 1.0
   \author S. Ansell
   \date July 2015
-  \brief VacuumPipe unit  
+  \brief VacuumPipe unit
 */
 
 class VacuumPipe :
@@ -59,7 +59,7 @@ class VacuumPipe :
   public attachSystem::FrontBackCut
 {
  private:
-  
+
   bool frontJoin;               ///< Flag for front join
   Geometry::Vec3D FPt;          ///< Front point
   Geometry::Vec3D FAxis;        ///< Front point
@@ -71,7 +71,7 @@ class VacuumPipe :
   double radius;                ///< void radius [inner]
   double height;                ///< void radius [inner]
   double width;                 ///< void radius [inner]
-  
+
   double length;                ///< void length [total]
 
   double feThick;               ///< pipe thickness
@@ -90,13 +90,14 @@ class VacuumPipe :
   int activeWindow;             ///< Flag on window activity
   windowInfo windowFront;       ///< Front window info
   windowInfo windowBack;        ///< Back window info
-    
+
   int voidMat;                  ///< Void material
   int feMat;                    ///< Pipe material
-  int claddingMat;              ///< Pipe cladding material 
-  
+  int claddingMat;              ///< Pipe cladding material
+  int flangeMat;                ///< Flange material
+
   size_t nDivision;             ///< Number divisions
-  
+
   void populate(const FuncDataBase&);
   void createUnitVector(const attachSystem::FixedComp&,const long int);
   void createSurfaces();
@@ -105,7 +106,7 @@ class VacuumPipe :
 
   void applyActiveFrontBack();
   void createDivision(Simulation&);
-  
+
  public:
 
   VacuumPipe(const std::string&);
@@ -125,4 +126,3 @@ class VacuumPipe :
 }
 
 #endif
- 

--- a/System/constructVar/PipeGenerator.cxx
+++ b/System/constructVar/PipeGenerator.cxx
@@ -65,7 +65,7 @@ PipeGenerator::PipeGenerator() :
   windowRadius(-2.0),windowThick(0.1),
   pipeMat("Aluminium"),frontWindowMat("Silicon300K"),
   backWindowMat("Silicon300K"),
-  voidMat("Void"),claddingMat("B4C")
+  voidMat("Void"),claddingMat("B4C"),flangeMat("Aluminium")
   /*!
     Constructor and defaults
   */
@@ -80,7 +80,7 @@ PipeGenerator::PipeGenerator(const PipeGenerator& A) :
   windowRadius(A.windowRadius),windowThick(A.windowThick),
   pipeMat(A.pipeMat),frontWindowMat(A.frontWindowMat),
   backWindowMat(A.backWindowMat),voidMat(A.voidMat),
-  claddingMat(A.claddingMat)
+  claddingMat(A.claddingMat),flangeMat(A.flangeMat)
   /*!
     Copy constructor
     \param A :: PipeGenerator to copy
@@ -114,6 +114,7 @@ PipeGenerator::operator=(const PipeGenerator& A)
       backWindowMat=A.backWindowMat;
       voidMat=A.voidMat;
       claddingMat=A.claddingMat;
+      flangeMat=A.flangeMat;
     }
   return *this;
 }
@@ -376,6 +377,7 @@ PipeGenerator::generatePipe(FuncDataBase& Control,const std::string& keyName,
 
   Control.addVariable(keyName+"CladdingThick",claddingThick);
   Control.addVariable(keyName+"CladdingMat",claddingMat);
+  Control.addVariable(keyName+"FlangeMat",flangeMat);
 
   return;
 

--- a/System/constructVarInc/PipeGenerator.h
+++ b/System/constructVarInc/PipeGenerator.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   constructVarInc/PipeGenerator.h
  *
  * Copyright (c) 2004-2019 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef setVariable_PipeGenerator_h
@@ -51,13 +51,14 @@ class PipeGenerator
   double flangeBLen;             ///< flange Length
   double windowRadius;          ///< window radius (radius > WR > flangeR)
   double windowThick;           ///< window thickness
-  
+
   std::string pipeMat;          ///< Primary default mat
   std::string frontWindowMat;   ///< window mat
   std::string backWindowMat;    ///< window mat
   std::string voidMat;          ///< void mat
   std::string claddingMat;      ///< Primary default mat
-    
+  std::string flangeMat;        ///< Flange material
+
  public:
 
   PipeGenerator();
@@ -73,18 +74,18 @@ class PipeGenerator
   void setAFlange(const double,const double);
   void setBFlange(const double,const double);
   void setFlangePair(const double,const double,const double,const double);
-  /// set pipe material
 
   template<typename CF> void setCF();
   template<typename CF> void setAFlangeCF();
   template<typename CF> void setBFlangeCF();
 
   /// setter for material name
-  void setMat(const std::string& M) { pipeMat=M; }
+  void setMat(const std::string& M, const std::string& FM="")
+  { pipeMat = M; flangeMat = FM=="" ? pipeMat : FM; }
   void setWindowMat(const std::string&);
   void setWindowMat(const std::string&,const std::string&);
   void setCladding(const double,const std::string&);
-  
+
   void generatePipe(FuncDataBase&,const std::string&,
 		    const double,const double) const;
 
@@ -93,4 +94,3 @@ class PipeGenerator
 }
 
 #endif
- 


### PR DESCRIPTION
Some TDC vacuum pipes have flanges made of different material than the pipe itself, so
I have added a corresponding variable in the ```VacuumPipe``` class.

Its default value is set to the pipe material and it can be changed in the ```PipeGenerator``` with the ```setMat``` function. This method now has an additional optional argument ```flangeMat```.

I have checked that these modifications do not change the SoftiMAX beam line geometry, where the ```PipeGenerator::setMat``` method is used.