### PR TITLE
Surface comments

### DIFF
--- a/CMake.pl
+++ b/CMake.pl
@@ -37,15 +37,15 @@ my @incdir=qw( include beamlineInc globalInc instrumentInc
 
 my @mainLib=qw( visit src simMC  construct physics input process
     transport scatMat endf crystal source monte funcBase log monte
-    flukaMagnetic flukaProcess flukaPhysics
-    flukaTally phitsProcess phitsPhysics
+    flukaProcess flukaPhysics
+    flukaTally phitsProcess 
     phitsTally phitsSupport tally
     geometry mersenne src world work
     xml poly support weights
     insertUnit md5 construct
     global constructVar physics simMC
-    scatMat endf crystal transport
-    attachComp visit poly);
+    transport attachComp visit poly flukaMagnetic phitsPhysics
+    scatMat endf crystal);
 
 my $gM=new CMakeList;
 $gM->setParameters(\@ARGV);
@@ -68,28 +68,26 @@ foreach my $mainProg (@masterProg)
   {
     if ($mainProg eq "ess")
       {
-	my @ess = qw( essBuild );
+	my @ess = qw( essBuild beer input );
+	push(@ess,@mainLib);
 	my @essSupport = qw( essConstruct commonVar common
-			     beer  bifrost  cspec  dream  estia
+			     bifrost  cspec  dream  estia
 			     freia  heimdal  loki  magic  miracles
 			     nmx  nnbar  odin  skadi  testBeam
 			     trex  vor  vespa shortOdin shortNmx
 			     shortDream simpleItem beamline instrument );
-	
-	push(@ess,@mainLib);
 	$gM->addDepUnit("ess", [@ess,@essSupport]);
       }
     elsif ($mainProg eq "essBeamline")
       {
-	my @essBeam = qw( essBuild );
+	my @essBeam = qw( essBuild beer input );
+	push(@essBeam,@mainLib);
 	my @essSupport = qw( essConstruct commonVar common
-			     beer  bifrost  cspec  dream  estia
+			     bifrost  cspec  dream  estia
 			     freia  heimdal  loki  magic  miracles
 			     nmx  nnbar  odin  skadi  testBeam
 			     trex  vor  vespa shortOdin shortNmx
 			     shortDream simpleItem beamline instrument );
-
-	push(@essBeam,@mainLib);
 	$gM->addDepUnit("essBeamline", [@essBeam,@essSupport]);
       }
     elsif ($mainProg eq "example")
@@ -101,10 +99,10 @@ foreach my $mainProg (@masterProg)
     
     elsif ($mainProg eq "maxiv")
       { 
-	my @maxiv = qw( maxivBuild );
+	my @maxiv = qw( maxivBuild balder cosaxs danmax );
 	push(@maxiv,@mainLib);
 	$gM->addDepUnit("maxiv", [@maxiv,
-				  qw(R3Common balder cosaxs danmax
+				  qw(R3Common
 				  flexpes formax maxpeem  micromax
 				  softimax
 				  commonGenerator commonBeam Linac
@@ -127,7 +125,7 @@ foreach my $mainProg (@masterProg)
     
     elsif ($mainProg eq "fullBuild")
       {
-	my @fullBuild = qw( build chip moderator build ralBuild zoom  );
+	my @fullBuild = qw( moderator build chip build ralBuild zoom  );
 	push(@fullBuild,@mainLib);
 	$gM->addDepUnit("fullBuild", [@fullBuild]),
       }
@@ -181,11 +179,10 @@ foreach my $mainProg (@masterProg)
     
     elsif ($mainProg eq "singleItem")
       { 
-	my @singleItem = qw( singleItemBuild ) ;
+	my @singleItem = qw( singleItemBuild commonVar commonGenerator R1Common R3Common ) ;
 	push(@singleItem,@mainLib);
 	$gM->addDepUnit("singleItem", [@singleItem,
-				       qw(commonGenerator commonVar
-				       commonBeam R1Common R3Common Linac )]);
+				       qw( commonBeam Linac )]);
       }
     
     

--- a/Model/essBuild/BilbaoWheel.cxx
+++ b/Model/essBuild/BilbaoWheel.cxx
@@ -457,7 +457,7 @@ BilbaoWheel::createShaftSurfaces()
   ModelSupport::buildPlane(SMap,buildIndex+2176,Origin+Z*H,Z);
 
   H += voidThick;
-  ModelSupport::buildPlane(SMap,buildIndex+2186,Origin+Z*H,Z,"z0=shaft2StepHeight+shaft2StepConnectionDist+shaft2StepConnectionHeight+voidThick");
+  ModelSupport::buildPlane(SMap,buildIndex+2186,Origin+Z*H,Z,"z0 = shaft2StepHeight + shaft2StepConnectionDist + shaft2StepConnectionHeight + voidThick");
 
   R = shaft2StepConnectionRadius;
   ModelSupport::buildCylinder(SMap,buildIndex+2127,Origin,Z,R);

--- a/Model/essBuild/BilbaoWheel.cxx
+++ b/Model/essBuild/BilbaoWheel.cxx
@@ -457,7 +457,7 @@ BilbaoWheel::createShaftSurfaces()
   ModelSupport::buildPlane(SMap,buildIndex+2176,Origin+Z*H,Z);
 
   H += voidThick;
-  ModelSupport::buildPlane(SMap,buildIndex+2186,Origin+Z*H,Z);
+  ModelSupport::buildPlane(SMap,buildIndex+2186,Origin+Z*H,Z,"z0=shaft2StepHeight+shaft2StepConnectionDist+shaft2StepConnectionHeight+voidThick");
 
   R = shaft2StepConnectionRadius;
   ModelSupport::buildCylinder(SMap,buildIndex+2127,Origin,Z,R);

--- a/System/geomInc/Surface.h
+++ b/System/geomInc/Surface.h
@@ -45,6 +45,7 @@ class Surface
   
   int Name;        ///< Surface number (MCNP identifier)
   int TransN;      ///< Transform number (-ve means applied)
+  std::string Comment; /// Comment to be added to the Surface definition
 
 
  protected:
@@ -76,6 +77,7 @@ class Surface
   int getName() const { return Name; }             ///< Get Name
   void setTrans(const int N) { TransN=N; }         ///< Set Transform number
   int getTrans() const { return TransN; }          ///< Get Transform number
+  void setComment(const std::string& C) { Comment=C; }; ///< Set Comment
 
   // Processes Name/TransNumber
   std::string stripID(const std::string&);
@@ -102,6 +104,8 @@ class Surface
   virtual void write(std::ostream&) const =0;
   
   /// \endcond ABSTRACT
+
+  void writeComment(std::ostream&) const;
 
   virtual void rotate(const Geometry::Quaternion&);
 

--- a/System/geometry/Surface.cxx
+++ b/System/geometry/Surface.cxx
@@ -46,6 +46,8 @@
 #include "Transform.h"
 #include "Line.h"
 #include "Surface.h"
+#include "support.h"
+#include "writeSupport.h"
 
 namespace Geometry
 {
@@ -64,7 +66,7 @@ operator<<(std::ostream& OX,const Surface& A)
 }
 
 Surface::Surface() : 
-  Name(-1),TransN(0)
+  Name(-1),TransN(0),Comment(std::string())
   /*!
     Constructor
   */
@@ -80,7 +82,7 @@ Surface::Surface(const int N,const int T) :
 {}
 
 Surface::Surface(const Surface& A) : 
-  Name(A.Name),TransN(A.TransN)
+  Name(A.Name),TransN(A.TransN),Comment(A.Comment)
   /*!
     Copy constructor
     \param A :: Surface to copy
@@ -100,6 +102,7 @@ Surface::operator=(const Surface& A)
     {
       Name=A.Name;
       TransN=A.TransN;
+      Comment=A.Comment;
     }
   return *this;
 }
@@ -152,6 +155,20 @@ Surface::writeHeader(std::ostream& OX) const
   OX<<Name<<" ";
   if (TransN>0)
     OX<<TransN<<" ";
+  return;
+}
+
+void
+Surface::writeComment(std::ostream& OX) const
+  /*!
+    Writes out the comment of a MCNP surface description
+    \param OX :: Output stream (required for multiple std::endl)
+  */
+{
+  if (!StrFunc::isEmpty(Comment)){
+      StrFunc::writeMCNPXcomment(" *** ",OX);
+      StrFunc::writeMCNPXcomment(Comment,OX);
+  }
   return;
 }
 

--- a/System/process/MainInputs.cxx
+++ b/System/process/MainInputs.cxx
@@ -141,6 +141,7 @@ createInputs(inputParam& IParam)
   IParam.regMulti("report","report",1000,0);
   IParam.regDefItem<std::string>("physModel","physicsModel",1,"CEM03"); 
 
+  IParam.regFlag("SC","SurfaceCommentsFlag");
   IParam.regFlag("sdefVoid","sdefVoid");
   IParam.regMulti("sdefType","sdefType",10,0);
   IParam.regItem("sdefFile","sdefFile");
@@ -272,6 +273,7 @@ createInputs(inputParam& IParam)
   IParam.setDesc("r","Renubmer cells");
   IParam.setDesc("report","Report a position/axis (show info on points etc)");
   IParam.setDesc("s","RND Seed");
+  IParam.setDesc("SC","Print comments in surface definitions");
   IParam.setDesc("sdefFile","File(s) for source");
   IParam.setDesc("sdefObj","Source Initialization Object");
   IParam.setDesc("sdefType","Source Type (TS1/TS2)");

--- a/System/process/MainProcess.cxx
+++ b/System/process/MainProcess.cxx
@@ -614,6 +614,7 @@ buildFullSimMCNP(SimMCNP* SimMCPtr,
   
   ModelSupport::setDefaultPhysics(*SimMCPtr,IParam);
   SimMCPtr->prepareWrite();
+  if (IParam.flag("SurfaceCommentsFlag")) SimMCPtr->setSurfaceCommentsFlag();
 
   // From tallybuilder
   tallySystem::tallySelection(*SimMCPtr,IParam);

--- a/System/process/generateSurf.cxx
+++ b/System/process/generateSurf.cxx
@@ -170,7 +170,8 @@ buildShiftedPlaneReversed(surfRegister& SMap,const int N,
 Geometry::Plane*
 buildPlane(surfRegister& SMap,const int N,
 	   const Geometry::Vec3D& A,const Geometry::Vec3D& B,
-	   const Geometry::Vec3D& C,const Geometry::Vec3D& normDir) 
+       const Geometry::Vec3D& C,const Geometry::Vec3D& normDir,
+       const std::string& Comment)
   /*!
     Simple constructor to build a surface [type plane]
     (based on three points
@@ -179,6 +180,7 @@ buildPlane(surfRegister& SMap,const int N,
     \param A :: First point
     \param B :: Second Point
     \param C :: Third Point
+    \param Comment :: Comment
     \param normDir :: Approximate normal direction [allow to force sign]
     \return New Plane Pointer
    */
@@ -192,6 +194,7 @@ buildPlane(surfRegister& SMap,const int N,
   const double DP=PX->getNormal().dotProd(normDir);
   if (DP<-Geometry::zeroTol)
     PX->mirrorSelf();
+  PX->setComment(Comment);
   const int NFound=SMap.registerSurf(N,PX);
 
   return SMap.realPtr<Geometry::Plane>(NFound);
@@ -199,13 +202,15 @@ buildPlane(surfRegister& SMap,const int N,
 
 Geometry::Plane*
 buildPlane(surfRegister& SMap,const int N,
-	   const Geometry::Vec3D& O,const Geometry::Vec3D& D) 
+       const Geometry::Vec3D& O,const Geometry::Vec3D& D,
+       const std::string& C)
   /*!
     Simple constructor to build a surface [type plane]
     \param SMap :: Surface Map
     \param N :: Surface number
     \param O :: Origin
     \param D :: Direction
+    \param C :: Comment
     \return New Plane Pointer
    */
 {
@@ -215,6 +220,7 @@ buildPlane(surfRegister& SMap,const int N,
 
   Geometry::Plane* PX=SurI.createUniqSurf<Geometry::Plane>(N);  
   PX->setPlane(O,D);
+  PX->setComment(C);
   const int NFound=SMap.registerSurf(N,PX);
 
   return SMap.realPtr<Geometry::Plane>(NFound);
@@ -222,13 +228,15 @@ buildPlane(surfRegister& SMap,const int N,
 
 Geometry::Plane*
 buildPlane(surfRegister& SMap,const int N,
-	   const Geometry::Vec3D& Norm,const double& Dist) 
+       const Geometry::Vec3D& Norm,const double& Dist,
+       const std::string& C)
   /*!
     Simple constructor to build a surface [type plane]
     \param SMap :: Surface Map
     \param N :: Surface number
     \param Norm :: Origin
     \param Dist :: Distance
+    \param C :: Comment
     \return New Plane Pointer
    */
 {
@@ -238,6 +246,8 @@ buildPlane(surfRegister& SMap,const int N,
 
   Geometry::Plane* PX=SurI.createUniqSurf<Geometry::Plane>(N);  
   PX->setPlane(Norm,Dist);
+  PX->setComment(C);
+
   const int NFound=SMap.registerSurf(N,PX);
 
   return SMap.realPtr<Geometry::Plane>(NFound);
@@ -246,7 +256,8 @@ buildPlane(surfRegister& SMap,const int N,
 Geometry::Plane*
 buildPlaneRotAxis(surfRegister& SMap,const int N,
 		  const Geometry::Vec3D& O,const Geometry::Vec3D& D,
-		  const Geometry::Vec3D& Axis,const double degAngle) 
+          const Geometry::Vec3D& Axis,const double degAngle,
+          const std::string& C)
   /*!
     Simple constructor to build a surface [type plane]
     The normal of the plane is rotated about the axis
@@ -256,6 +267,7 @@ buildPlaneRotAxis(surfRegister& SMap,const int N,
     \param D :: Direction before rotation
     \param Axis :: Axis to rotate about 
     \param degAngle :: Angle to rotate about [deg]
+    \param C :: Comment
     \return New Plane Pointer
    */
 {
@@ -267,6 +279,7 @@ buildPlaneRotAxis(surfRegister& SMap,const int N,
   Geometry::Vec3D RotNorm(D);
   Geometry::Quaternion::calcQRotDeg(degAngle,Axis).rotate(RotNorm);  
   PX->setPlane(O,RotNorm);
+  PX->setComment(C);
   const int NFound=SMap.registerSurf(N,PX);
 
   return SMap.realPtr<Geometry::Plane>(NFound);
@@ -275,7 +288,7 @@ buildPlaneRotAxis(surfRegister& SMap,const int N,
 Geometry::Cylinder*
 buildCylinder(surfRegister& SMap,const int N,
 	      const Geometry::Vec3D& O,const Geometry::Vec3D& D,
-	      const double R) 
+          const double R,const std::string& C)
   /*!
     Simple constructor to build a surface [type Cylinder]
     \param SMap :: Surface Map
@@ -283,6 +296,7 @@ buildCylinder(surfRegister& SMap,const int N,
     \param O :: Origin
     \param D :: Direction
     \param R :: Radius
+    \param C :: Comment
     \return New cylinder pointer
    */
 {
@@ -296,6 +310,7 @@ buildCylinder(surfRegister& SMap,const int N,
 				 "Origin = "+StrFunc::makeString(O),
 				 "Dir    = "+StrFunc::makeString(D),
 				 "Radius = "+StrFunc::makeString(R));
+  CX->setComment(C);
   const int NFound=SMap.registerSurf(N,CX);
 
   return SMap.realPtr<Geometry::Cylinder>(NFound);
@@ -307,7 +322,8 @@ buildCone(surfRegister& SMap,const int N,
 	  const Geometry::Vec3D& circleCent,
 	  const double radius,
 	  const Geometry::Vec3D& Axis,
-	  const double angleDeg) 
+          const double angleDeg,
+          const std::string& C)
   /*!
     Simple constructor to build a surface [type Cone]
     \param SMap :: Surface Map
@@ -330,6 +346,7 @@ buildCone(surfRegister& SMap,const int N,
   ELog::EM<<"Cone == "<<circleCent-Axis.unit()*D<<ELog::endDiag;
   Geometry::Cone* CX=SurI.createUniqSurf<Geometry::Cone>(N);  
   CX->setCone(circleCent-Axis.unit()*D,Axis,angleDeg);
+  CX->setComment(C);
   const int NFound=SMap.registerSurf(N,CX);
 
 
@@ -340,7 +357,8 @@ Geometry::Cone*
 buildCone(surfRegister& SMap,const int N,
 	  const Geometry::Vec3D& O,
 	  const Geometry::Vec3D& A,
-	  const double angleDeg) 
+          const double angleDeg,
+          const std::string& C)
   /*!
     Simple constructor to build a surface [type Cone]
     \param SMap :: Surface Map
@@ -348,6 +366,7 @@ buildCone(surfRegister& SMap,const int N,
     \param O :: Origin
     \param A :: Axis
     \param angleDeg :: Angle in degrees
+    \param C :: Comment
     \return New cone
    */
 {
@@ -357,6 +376,7 @@ buildCone(surfRegister& SMap,const int N,
 
   Geometry::Cone* CX=SurI.createUniqSurf<Geometry::Cone>(N);  
   CX->setCone(O,A,angleDeg);
+  CX->setComment(C);
   const int NFound=SMap.registerSurf(N,CX);
 
   return SMap.realPtr<Geometry::Cone>(NFound);
@@ -367,7 +387,8 @@ buildCone(surfRegister& SMap,const int N,
 	  const Geometry::Vec3D& CentPt,
 	  const Geometry::Vec3D& Axis,
 	  const Geometry::Vec3D& APt,
-	  const Geometry::Vec3D& BPt)
+          const Geometry::Vec3D& BPt,
+          const std::string& C)
   /*!
     Simple constructor to build a surface [type Cone]
     Assumption is that the Points APt and BPt are at
@@ -378,6 +399,7 @@ buildCone(surfRegister& SMap,const int N,
     \param Axis :: Forward Axis of cone
     \param APt :: Point on cone
     \param BPt :: Point on cone
+    \param C :: Comment
     \return New cone
    */
 {
@@ -417,6 +439,7 @@ buildCone(surfRegister& SMap,const int N,
   
   Geometry::Cone* CX=SurI.createUniqSurf<Geometry::Cone>(N);  
   CX->setCone(coneCent,AUnit,180.0*acos(cosAng)/M_PI);
+  CX->setComment(C);
   const int NFound=SMap.registerSurf(N,CX);
 
   return SMap.realPtr<Geometry::Cone>(NFound);
@@ -426,7 +449,8 @@ Geometry::Cone*
 buildCone(surfRegister& SMap,const int N,
 	  const Geometry::Vec3D& O,
 	  const Geometry::Vec3D& A,
-	  const double angleDeg,const int cutFlag) 
+          const double angleDeg,const int cutFlag, 
+          const std::string& C)
   /*!
     Simple constructor to build a surface [type Cone]
     \param SMap :: Surface Map
@@ -435,6 +459,7 @@ buildCone(surfRegister& SMap,const int N,
     \param A :: Axis
     \param angleDeg :: Angle in degrees
     \param cutFlag :: addtional cut flag
+    \param C :: Comment
     \return New cone
    */
 {
@@ -445,6 +470,7 @@ buildCone(surfRegister& SMap,const int N,
   Geometry::Cone* CX=SurI.createUniqSurf<Geometry::Cone>(N);  
   CX->setCone(O,A,angleDeg);
   CX->setCutFlag(cutFlag);
+  CX->setComment(C);
   const int NFound=SMap.registerSurf(N,CX);
 
   return SMap.realPtr<Geometry::Cone>(NFound);
@@ -452,13 +478,15 @@ buildCone(surfRegister& SMap,const int N,
 
 Geometry::Sphere*
 buildSphere(surfRegister& SMap,const int N,
-	    const Geometry::Vec3D& O,const double R) 
+            const Geometry::Vec3D& O,const double R,
+            const std::string& C)
   /*!
     Simple constructor to build a surface [type Cylinder]
     \param SMap :: Surface Map
     \param N :: Surface number
     \param O :: Origin
     \param R :: Radius
+    \param C :: Comment
     \return New sphere pointer
    */
 {
@@ -468,6 +496,7 @@ buildSphere(surfRegister& SMap,const int N,
 
   Geometry::Sphere* SX=SurI.createUniqSurf<Geometry::Sphere>(N);  
   SX->setSphere(O,R);
+  SX->setComment(C);
   const int NFound=SMap.registerSurf(N,SX);
   return SMap.realPtr<Geometry::Sphere>(NFound);
 }
@@ -477,7 +506,8 @@ buildEllipticCyl(surfRegister& SMap,const int N,
 		 const Geometry::Vec3D& O,
 		 const Geometry::Vec3D& D,
 		 const Geometry::Vec3D& LA,
-		 const double RA,const double RB) 
+                 const double RA,const double RB,
+                 const std::string& C)
   /*!
     Simple constructor to build a surface [type Cylinder]
     \param SMap :: Surface Map
@@ -487,6 +517,7 @@ buildEllipticCyl(surfRegister& SMap,const int N,
     \param LA :: RA-X direction
     \param RA :: Radius
     \param RB :: Radius
+    \param C :: Comment
     \return New cylinder pointer
    */
 {
@@ -496,6 +527,7 @@ buildEllipticCyl(surfRegister& SMap,const int N,
 
   Geometry::EllipticCyl* EX=SurI.createUniqSurf<Geometry::EllipticCyl>(N);  
   EX->setEllipticCyl(O,D,LA,RA,RB);
+  EX->setComment(C);
 
   const int NFound=SMap.registerSurf(N,EX);
   return SMap.realPtr<Geometry::EllipticCyl>(NFound);

--- a/System/processInc/generateSurf.h
+++ b/System/processInc/generateSurf.h
@@ -48,51 +48,61 @@ buildShiftedPlaneReversed(surfRegister&,const int,
 Geometry::Plane*
 buildPlaneRotAxis(surfRegister&,const int,
 		  const Geometry::Vec3D&,const Geometry::Vec3D&,
-		  const Geometry::Vec3D&,const double);
+                  const Geometry::Vec3D&,const double,
+                  const std::string& C=std::string());
 
 Geometry::Plane* 
 buildPlane(surfRegister&,const int,const Geometry::Vec3D&,
 	   const Geometry::Vec3D&,const Geometry::Vec3D&,
-	   const Geometry::Vec3D&);
+           const Geometry::Vec3D&,
+           const std::string& Comment=std::string());
 
 Geometry::Plane* 
 buildPlane(surfRegister&,const int,const Geometry::Vec3D&,
-	   const Geometry::Vec3D&);
+           const Geometry::Vec3D&,
+           const std::string& C=std::string());
 
 Geometry::Plane* 
 buildPlane(surfRegister&,const int,const Geometry::Vec3D&,
-	   const double&);
+           const double&,
+           const std::string& C=std::string());
 
 Geometry::Cylinder* 
 buildCylinder(surfRegister&,const int,const Geometry::Vec3D&,
-	      const Geometry::Vec3D&,const double);
+          const Geometry::Vec3D&,const double,
+          const std::string& C=std::string());
 
 Geometry::Sphere* 
-buildSphere(surfRegister&,const int,const Geometry::Vec3D&,const double);
+buildSphere(surfRegister&,const int,const Geometry::Vec3D&,const double,
+            const std::string& C=std::string());
 
 Geometry::Cone* 
 buildCone(surfRegister&,const int,const Geometry::Vec3D&,
 	  const Geometry::Vec3D&,const Geometry::Vec3D&,
-	  const Geometry::Vec3D&);
+          const Geometry::Vec3D&,
+          const std::string& C=std::string());
 
 Geometry::Cone* 
 buildCone(surfRegister&,const int,
 	  const Geometry::Vec3D&,const double,
-	  const Geometry::Vec3D&,const double);
+          const Geometry::Vec3D&,const double,
+          const std::string& C=std::string());
 
 Geometry::Cone* 
 buildCone(surfRegister&,const int,const Geometry::Vec3D&,
-	  const Geometry::Vec3D&,const double);
+          const Geometry::Vec3D&,const double,
+          const std::string& C=std::string());
 
 Geometry::Cone* 
 buildCone(surfRegister&,const int,const Geometry::Vec3D&,
-	  const Geometry::Vec3D&,const double,const int);
+          const Geometry::Vec3D&,const double,const int,
+          const std::string& C=std::string());
 
 Geometry::EllipticCyl* 
 buildEllipticCyl(surfRegister&,const int,const Geometry::Vec3D&,
 		 const Geometry::Vec3D&,
 		 const Geometry::Vec3D&,const double,
-		 const double);
+                 const double, const std::string& C=std::string());
 
 
  

--- a/include/SimMCNP.h
+++ b/include/SimMCNP.h
@@ -84,6 +84,8 @@ class SimMCNP : public Simulation
 
   physicsSystem::PhysicsCards* PhysPtr;   ///< Physics Cards
 
+  bool SurfaceCommentsFlag;
+
 
   void deleteTally();
   
@@ -112,6 +114,10 @@ class SimMCNP : public Simulation
 
   /// is the system MCNP6
   bool isMCNP6() const { return mcnpVersion!=10; }
+
+  bool hasSurfaceComments() const { return SurfaceCommentsFlag; }
+
+  void setSurfaceCommentsFlag() { SurfaceCommentsFlag = true; }
 
   // processing for Simulation
   virtual void removeCell(const int);

--- a/src/SimMCNP.cxx
+++ b/src/SimMCNP.cxx
@@ -113,7 +113,8 @@
 SimMCNP::SimMCNP()  :
   Simulation(),
   mcnpVersion(6),
-  PhysPtr(new physicsSystem::PhysicsCards)
+  PhysPtr(new physicsSystem::PhysicsCards),
+  SurfaceCommentsFlag(false)
   
   /*!
     Start of simulation Object
@@ -490,9 +491,10 @@ SimMCNP::writeSurfaces(std::ostream& OX) const
   const ModelSupport::surfIndex::STYPE& SurMap =
     ModelSupport::surfIndex::Instance().surMap();
   
-  for(const ModelSupport::surfIndex::STYPE::value_type& sm : SurMap)
+  for(const ModelSupport::surfIndex::STYPE::value_type& sm : SurMap){
+    if (SimMCNP::hasSurfaceComments()) sm.second->writeComment(OX);
     sm.second->write(OX);
-
+  }
   OX<<"c ++++++++++++++++++++++ END ++++++++++++++++++++++++++++"<<std::endl;
   OX<<std::endl;
   return;


### PR DESCRIPTION
Comments are added as an optional string argument in ModelSupport::buildPlane(), ModelSupport::buildCylinder(), etc. See BilbaoWheel::createSurfaces() for an example of usage.

Output of comments to the MCNP file is controlled by the -SC command line flag.

(Additionally: order in Cmake.pl was changed to make it run with gcc 7.4.0)