### PR TITLE
BPM: electrode -> stripline

### DIFF
--- a/Model/MaxIV/Linac/BPM.cxx
+++ b/Model/MaxIV/Linac/BPM.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   Linac/BPM.cxx
  *
  * Copyright (c) 2004-2020 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -70,15 +70,15 @@
 #include "ModelSupport.h"
 #include "MaterialSupport.h"
 #include "generateSurf.h"
-#include "LinkUnit.h"  
+#include "LinkUnit.h"
 #include "FixedComp.h"
 #include "FixedOffset.h"
 #include "ContainedComp.h"
 #include "ExternalCut.h"
-#include "FrontBackCut.h" 
+#include "FrontBackCut.h"
 #include "BaseMap.h"
 #include "SurfMap.h"
-#include "CellMap.h" 
+#include "CellMap.h"
 
 #include "BPM.h"
 
@@ -98,7 +98,7 @@ BPM::BPM(const std::string& Key) :
 {}
 
 
-BPM::~BPM() 
+BPM::~BPM()
   /*!
     Destructor
   */
@@ -114,11 +114,11 @@ BPM::populate(const FuncDataBase& Control)
   ELog::RegMethod RegA("BPM","populate");
 
   FixedOffset::populate(Control);
-  
+
   radius=Control.EvalVar<double>(keyName+"Radius");
   length=Control.EvalVar<double>(keyName+"Length");
   outerThick=Control.EvalVar<double>(keyName+"OuterThick");
-  
+
   innerRadius=Control.EvalVar<double>(keyName+"InnerRadius");
   innerThick=Control.EvalVar<double>(keyName+"InnerThick");
 
@@ -135,14 +135,14 @@ BPM::populate(const FuncDataBase& Control)
   flangeBLength=Control.EvalHead<double>
     (keyName,"FlangeBLength","FlangeLength");
 
-  electrodeRadius=Control.EvalVar<double>(keyName+"ElectrodeRadius");
-  electrodeThick=Control.EvalVar<double>(keyName+"ElectrodeThick");
-  electrodeEnd=Control.EvalVar<double>(keyName+"ElectrodeEnd");
-  electrodeYStep=Control.EvalVar<double>(keyName+"ElectrodeYStep");
-  
+  striplineRadius=Control.EvalVar<double>(keyName+"StriplineRadius");
+  striplineThick=Control.EvalVar<double>(keyName+"StriplineThick");
+  striplineEnd=Control.EvalVar<double>(keyName+"StriplineEnd");
+  striplineYStep=Control.EvalVar<double>(keyName+"StriplineYStep");
+
   voidMat=ModelSupport::EvalMat<int>(Control,keyName+"VoidMat");
   flangeMat=ModelSupport::EvalMat<int>(Control,keyName+"FlangeMat");
-  electrodeMat=ModelSupport::EvalMat<int>(Control,keyName+"ElectrodeMat");
+  striplineMat=ModelSupport::EvalMat<int>(Control,keyName+"StriplineMat");
   outerMat=ModelSupport::EvalMat<int>(Control,keyName+"OuterMat");
 
   return;
@@ -171,7 +171,7 @@ BPM::createSurfaces()
   // main pipe and thicness
   ModelSupport::buildCylinder(SMap,buildIndex+7,Origin,Y,radius);
   ModelSupport::buildCylinder(SMap,buildIndex+17,Origin,Y,radius+outerThick);
-  
+
   ModelSupport::buildCylinder(SMap,buildIndex+107,Origin,Y,flangeARadius);
   ModelSupport::buildCylinder(SMap,buildIndex+207,Origin,Y,flangeBRadius);
 
@@ -197,13 +197,13 @@ BPM::createSurfaces()
       midAngle+=M_PI/2.0;
       BI+=2;
     }
-      
+
   // end point on electrons (solid)
   ModelSupport::buildPlane(SMap,buildIndex+302,
-			   Origin+Y*(length/2.0-electrodeEnd),Y);
+			   Origin+Y*(length/2.0-striplineEnd),Y);
 
-  
-  // Electrode holder
+
+  // Stripline holder
   const double angleStep(M_PI/4.0);
 
   BI=buildIndex+411;
@@ -211,16 +211,16 @@ BPM::createSurfaces()
     {
       const double angle(angleStep*static_cast<double>(i));
       const Geometry::Vec3D axis(X*cos(angle)+Z*sin(angle));
-      ModelSupport::buildPlane(SMap,BI,Origin+axis*electrodeRadius,axis);
+      ModelSupport::buildPlane(SMap,BI,Origin+axis*striplineRadius,axis);
       BI++;
     }
 
-  const Geometry::Vec3D eCent(Origin+Y*(electrodeYStep-length/2.0));
+  const Geometry::Vec3D eCent(Origin+Y*(striplineYStep-length/2.0));
   ModelSupport::buildPlane
-    (SMap,buildIndex+401,eCent-Y*(electrodeThick/2.0),Y);
+    (SMap,buildIndex+401,eCent-Y*(striplineThick/2.0),Y);
   ModelSupport::buildPlane
-    (SMap,buildIndex+402,eCent+Y*(electrodeThick/2.0),Y);
-  
+    (SMap,buildIndex+402,eCent+Y*(striplineThick/2.0),Y);
+
   return;
 }
 
@@ -234,7 +234,7 @@ BPM::createObjects(Simulation& System)
   ELog::RegMethod RegA("BPM","createObjects");
 
   std::string Out;
-  
+
   const std::string frontStr=getRuleStr("front");
   const std::string backStr=getRuleStr("back");
 
@@ -242,7 +242,7 @@ BPM::createObjects(Simulation& System)
   Out=ModelSupport::getComposite(SMap,buildIndex," -307 ");
   makeCell("Void",System,cellIndex++,voidMat,0.0,Out+frontStr+backStr);
 
-  
+
   // front void
   Out=ModelSupport::getComposite(SMap,buildIndex," -7 307 -401 ");
   makeCell("FrontVoid",System,cellIndex++,voidMat,0.0,Out+frontStr);
@@ -261,17 +261,17 @@ BPM::createObjects(Simulation& System)
 
   Out=ModelSupport::getComposite
     (SMap,buildIndex," 17 401 -402 -411 -412 -413 -414 -415 -416 -417 -418 ");
-  makeCell("ElectronPlate",System,cellIndex++,electrodeMat,0.0,Out);
+  makeCell("ElectronPlate",System,cellIndex++,striplineMat,0.0,Out);
 
 
   Out=ModelSupport::getComposite
     (SMap,buildIndex," 101 17 -401 -411 -412 -413 -414 -415 -416 -417 -418 ");
   makeCell("OuterVoid",System,cellIndex++,voidMat,0.0,Out);
-  
+
   Out=ModelSupport::getComposite
     (SMap,buildIndex," -202 17 402 -411 -412 -413 -414 -415 -416 -417 -418 ");
   makeCell("OuterVoid",System,cellIndex++,voidMat,0.0,Out);
-  
+
   Out=ModelSupport::getComposite
     (SMap,buildIndex," -101 107 -411 -412 -413 -414 -415 -416 -417 -418 ");
   makeCell("OuterVoid",System,cellIndex++,voidMat,0.0,Out+frontStr);
@@ -282,14 +282,14 @@ BPM::createObjects(Simulation& System)
 
   int BI(0);
   const std::string IOut=
-    ModelSupport::getComposite(SMap,buildIndex," 401 -302  307 -317 "); 
+    ModelSupport::getComposite(SMap,buildIndex," 401 -302  307 -317 ");
   for(size_t i=0;i<4;i++)
     {
       Out=ModelSupport::getComposite(SMap,buildIndex+BI," 351 -352");
-      makeCell("Electrode",System,cellIndex++,electrodeMat,0.0,IOut+Out);
+      makeCell("Stripline",System,cellIndex++,striplineMat,0.0,IOut+Out);
       Out=ModelSupport::getRangeComposite
 	(SMap,351,358,BI,buildIndex," 352R -353R");
-      makeCell("ElectrodeGap",System,cellIndex++,voidMat,0.0,IOut+Out);
+      makeCell("StriplineGap",System,cellIndex++,voidMat,0.0,IOut+Out);
       BI+=2;
     }
   // edge electrod void
@@ -298,17 +298,17 @@ BPM::createObjects(Simulation& System)
 
   // edge electrod void
   Out=ModelSupport::getComposite(SMap,buildIndex," 302  307 -7");
-  makeCell("ElectrodeEnd",System,cellIndex++,electrodeMat,0.0,Out+backStr);
+  makeCell("StriplineEnd",System,cellIndex++,striplineMat,0.0,Out+backStr);
 
 
   Out=ModelSupport::getComposite
       (SMap,buildIndex," -411 -412 -413 -414 -415 -416 -417 -418 ");
   addOuterSurf(Out);
-  
+
   return;
 }
 
-void 
+void
 BPM::createLinks()
   /*!
     Create the linked units
@@ -318,7 +318,7 @@ BPM::createLinks()
 
   ExternalCut::createLink("front",*this,0,Origin,Y);  //front and back
   ExternalCut::createLink("back",*this,1,Origin,Y);  //front and back
-      
+
   return;
 }
 
@@ -329,20 +329,20 @@ BPM::createAll(Simulation& System,
   /*!
     Generic function to create everything
     \param System :: Simulation item
-    \param FC :: Fixed point track 
+    \param FC :: Fixed point track
     \param sideIndex :: link point
   */
 {
   ELog::RegMethod RegA("BPM","createAll");
-  
+
   populate(System.getDataBase());
   createCentredUnitVector(FC,sideIndex,length);
   createSurfaces();
   createObjects(System);
   createLinks();
-  insertObjects(System);   
-  
+  insertObjects(System);
+
   return;
 }
-  
+
 }  // NAMESPACE tdcSystem

--- a/Model/MaxIV/LinacInc/BPM.h
+++ b/Model/MaxIV/LinacInc/BPM.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   LinacInc/BPM.h
  *
  * Copyright (c) 2004-2020 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef tdcSystem_BPM_h
@@ -45,33 +45,33 @@ class BPM :
 {
  private:
 
-  double radius;                ///< void radius   
+  double radius;                ///< void radius
   double length;                ///< void length [total]
 
   double outerThick;            ///< pipe thickness
 
   double innerRadius;           ///< inner radius
   double innerThick;            ///< Inner electorn thickness
-  double innerAngle;            ///< Angle of electrode
+  double innerAngle;            ///< Angle of stripline
   double innerAngleOffset;      ///< Offset angle of inner electron
 
-  double flangeARadius;         ///< Joining Flange radius 
+  double flangeARadius;         ///< Joining Flange radius
   double flangeALength;         ///< Joining Flange length
 
-  double flangeBRadius;         ///< Joining Flange radius 
+  double flangeBRadius;         ///< Joining Flange radius
   double flangeBLength;         ///< Joining Flange length
 
-  double electrodeRadius;       ///< Electrode distance [support]
-  double electrodeThick;        ///< Electrode thickness [support]
-  double electrodeYStep;        ///< Electrode YStep
-  double electrodeEnd;          ///< Electrode end piece length
-  
+  double striplineRadius;       ///< Stripline distance [support]
+  double striplineThick;        ///< Stripline thickness [support]
+  double striplineYStep;        ///< Stripline YStep
+  double striplineEnd;          ///< Stripline end piece length
+
   int voidMat;                  ///< void material
-  int electrodeMat;             ///< electrode material
-  int flangeMat;                ///< flange material  
+  int striplineMat;             ///< stripline material
+  int flangeMat;                ///< flange material
   int outerMat;                 ///< pipe material
 
-  void populate(const FuncDataBase&);  
+  void populate(const FuncDataBase&);
   void createSurfaces();
   void createObjects(Simulation&);
   void createLinks();
@@ -93,4 +93,3 @@ class BPM :
 }
 
 #endif
- 

--- a/Model/MaxIV/commonGenerator/BPMGenerator.cxx
+++ b/Model/MaxIV/commonGenerator/BPMGenerator.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   commonGenerator/BPMGenerator.cxx
  *
  * Copyright (c) 2004-2020 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -63,16 +63,16 @@ BPMGenerator::BPMGenerator() :
   innerAngle(30.0),innerAngleOffset(45.0),
   flangeARadius(CF40::flangeRadius),flangeALength(CF40::flangeLength),
   flangeBRadius(CF40::flangeRadius),flangeBLength(CF40::flangeLength),
-  electrodeRadius(3.7),electrodeThick(2.4),
-  electrodeYStep(3.1),electrodeEnd(4.0),
-  voidMat("Void"),electrodeMat("Copper"),
-  flangeMat("Stainless304"),outerMat("Stainless304")
+  striplineRadius(3.7),striplineThick(2.4),
+  striplineYStep(3.1),striplineEnd(4.0),
+  voidMat("Void"),striplineMat("Stainless304L"),
+  flangeMat("Stainless304L"),outerMat("Stainless304L")
   /*!
     Constructor and defaults
   */
 {}
-  
-BPMGenerator::~BPMGenerator() 
+
+BPMGenerator::~BPMGenerator()
  /*!
    Destructor
  */
@@ -114,14 +114,14 @@ BPMGenerator::setBFlangeCF()
   return;
 }
 
-    
+
 void
 BPMGenerator::generateBPM(FuncDataBase& Control,
 			  const std::string& keyName,
 			  const double yStep)  const
 /*!
     Primary funciton for setting the variables
-    \param Control :: Database to add variables 
+    \param Control :: Database to add variables
     \param keyName :: head name for variable
     \param yStep :: Step along beam centre
   */
@@ -144,17 +144,17 @@ BPMGenerator::generateBPM(FuncDataBase& Control,
   Control.addVariable(keyName+"FlangeBRadius",flangeBRadius);
   Control.addVariable(keyName+"FlangeBLength",flangeBLength);
 
-  Control.addVariable(keyName+"ElectrodeRadius",electrodeRadius);
-  Control.addVariable(keyName+"ElectrodeThick",electrodeThick);
-  Control.addVariable(keyName+"ElectrodeYStep",electrodeYStep);
-  Control.addVariable(keyName+"ElectrodeEnd",electrodeEnd);
+  Control.addVariable(keyName+"StriplineRadius",striplineRadius);
+  Control.addVariable(keyName+"StriplineThick",striplineThick);
+  Control.addVariable(keyName+"StriplineYStep",striplineYStep);
+  Control.addVariable(keyName+"StriplineEnd",striplineEnd);
 
   Control.addVariable(keyName+"VoidMat",voidMat);
-  Control.addVariable(keyName+"ElectrodeMat",electrodeMat);
+  Control.addVariable(keyName+"StriplineMat",striplineMat);
   Control.addVariable(keyName+"FlangeMat",flangeMat);
   Control.addVariable(keyName+"OuterMat",outerMat);
-  
-    
+
+
   return;
 
 }
@@ -171,5 +171,5 @@ template void BPMGenerator::setBFlangeCF<CF40_22>();
 template void BPMGenerator::setBFlangeCF<CF40>();
 
 ///\endcond TEPLATE
-  
+
 }  // NAMESPACE setVariable

--- a/Model/MaxIV/commonGeneratorInc/BPMGenerator.h
+++ b/Model/MaxIV/commonGeneratorInc/BPMGenerator.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   commonGeneratorInc/BPMGenerator.h
  *
  * Copyright (c) 2004-2020 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef setVariable_BPMGenerator_h
@@ -35,37 +35,37 @@ namespace setVariable
   \brief BPMGenerator for variables
 */
 
-class BPMGenerator 
+class BPMGenerator
 {
  private:
 
-  double radius;                ///< void radius   
+  double radius;                ///< void radius
   double length;                ///< void length [total]
 
   double outerThick;            ///< pipe thickness
 
   double innerRadius;           ///< inner radius
   double innerThick;            ///< Inner electorn thickness
-  double innerAngle;            ///< Angle of electrode
+  double innerAngle;            ///< Angle of stripline
   double innerAngleOffset;      ///< Offset angle of inner electron
 
-  double flangeARadius;         ///< Joining Flange radius 
+  double flangeARadius;         ///< Joining Flange radius
   double flangeALength;         ///< Joining Flange length
 
-  double flangeBRadius;         ///< Joining Flange radius 
+  double flangeBRadius;         ///< Joining Flange radius
   double flangeBLength;         ///< Joining Flange length
 
-  double electrodeRadius;       ///< Electrode distance [support]
-  double electrodeThick;        ///< Electrode thickness [support]
-  double electrodeYStep;        ///< Electrode YStep
-  double electrodeEnd;          ///< Electrode end piece length
-  
+  double striplineRadius;       ///< Stripline distance [support]
+  double striplineThick;        ///< Stripline thickness [support]
+  double striplineYStep;        ///< Stripline YStep
+  double striplineEnd;          ///< Stripline end piece length
+
   std::string voidMat;                  ///< void material
-  std::string electrodeMat;             ///< electrode material
-  std::string flangeMat;                ///< flange material  
+  std::string striplineMat;             ///< stripline material
+  std::string flangeMat;                ///< flange material
   std::string outerMat;                 ///< pipe material
 
-  
+
  public:
 
   BPMGenerator();
@@ -76,7 +76,7 @@ class BPMGenerator
   template<typename T> void setCF();
   template<typename T> void setAFlangeCF();
   template<typename T> void setBFlangeCF();
-  
+
   virtual void generateBPM(FuncDataBase&,const std::string&,
 			   const double) const;
 
@@ -85,4 +85,3 @@ class BPMGenerator
 }
 
 #endif
- 


### PR DESCRIPTION
BPM electrode renamed to stripline and its material changed from Copper to Stainless304L (as explained by Erik).