### PR TITLE
Change of cmd argumens for PHITS / POV-Ray output

### DIFF
--- a/System/process/MainInputs.cxx
+++ b/System/process/MainInputs.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   process/MainInputs.cxx
  *
  * Copyright (c) 2004-2020 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -63,7 +63,7 @@ createPHITSInputs(inputParam& IParam)
   IParam.setDesc("icntl","Control parameter for output");
   return;
 }
-  
+
 void
 createInputs(inputParam& IParam)
   /*!
@@ -76,7 +76,7 @@ createInputs(inputParam& IParam)
   std::vector<std::string> RItems(10,"");
 
   createPHITSInputs(IParam);
-  
+
   IParam.regMulti("activation","activation",10000,1);
 
   IParam.regFlag("a","axis");
@@ -110,7 +110,7 @@ createInputs(inputParam& IParam)
   IParam.regDefItemList<std::string>("imp","importance",10,RItems);
   IParam.regDefItem<int>("m","multi",1,1);
   IParam.regDefItem<std::string>("matDB","materialDatabase",1,
-                                 std::string("shielding"));  
+                                 std::string("shielding"));
   IParam.regItem("matFile","matFile");
   IParam.regItem("maxEnergy","maxEnergy");   // default max energy
   IParam.regFlag("M","mesh");
@@ -122,9 +122,9 @@ createInputs(inputParam& IParam)
   IParam.regItem("memStack","memStack");
   IParam.regDefItem<int>("n","nps",1,10000);
   IParam.regItem("noVariables","noVariables");
-  IParam.regFlag("p","PHITS");
   IParam.regFlag("fluka","FLUKA");
-  IParam.regItem("povray","PovRay");
+  IParam.regItem("povray","POVRAY");
+  IParam.regFlag("phits","PHITS");
   IParam.regDefItem<int>("mcnp","MCNP",1,6);
   IParam.regFlag("Monte","Monte");
   IParam.regFlag("noThermal","noThermal");
@@ -134,12 +134,12 @@ createInputs(inputParam& IParam)
   IParam.regDefItem<double>("photonModel","photonModel",1,100.0);
   IParam.regMulti("postOffset","postOffset",10000,1,8);
   IParam.regDefItem<std::string>("print","printTable",1,
-				 "10 20 40 50 110 120");  
+				 "10 20 40 50 110 120");
   IParam.regItem("PTRAC","ptrac");
 
   IParam.regItem("r","renum");
   IParam.regMulti("report","report",1000,0);
-  IParam.regDefItem<std::string>("physModel","physicsModel",1,"CEM03"); 
+  IParam.regDefItem<std::string>("physModel","physicsModel",1,"CEM03");
 
   IParam.regFlag("sdefVoid","sdefVoid");
   IParam.regMulti("sdefType","sdefType",10,0);
@@ -148,7 +148,7 @@ createInputs(inputParam& IParam)
   IParam.regMulti("sdefSourceName","sdefSourceName",1000,0);
   IParam.regMulti("sdefMod","sdefMod",1000,0);
   IParam.regMulti("sdefObj","sdefObj",1000,0);
-  IParam.regItem("singleItem","singleItem");  
+  IParam.regItem("singleItem","singleItem");
   IParam.regDefItem<long int>("s","random",1,375642321L);
   // std::vector<std::string> AItems(15);
   // IParam.regDefItemList<std::string>("T","tally",15,AItems);
@@ -171,7 +171,7 @@ createInputs(inputParam& IParam)
   IParam.regItem("volCard","volCard");
   IParam.regDefItem<int>("VN","volNum",1,20000);
   IParam.regMulti("volCell","volCells",100,1,100);
-    
+
   IParam.regFlag("void","void");
   IParam.regMulti("voidObject","voidObject",1000);
   IParam.regItem("vtkMesh","vtkMesh",1);
@@ -207,7 +207,7 @@ createInputs(inputParam& IParam)
   IParam.regMulti("wLAM","wLAM",1000,0);
   IParam.regMulti("wCUT","wCUT",1000,0);
   IParam.regMulti("wMAT","wMAT",1000,0);
-  
+
   IParam.regMulti("wwgE","wwgE",25,0);
   IParam.regItem("wwgVTK","wwgVTK",1,10);
   IParam.regItem("wwgNorm","wwgNorm",0,30);
@@ -217,8 +217,8 @@ createInputs(inputParam& IParam)
   IParam.regItem("wwgRPtMesh","wwgRPtMesh",1,125);
   IParam.regItem("wwgXMesh","wwgXMesh",3,125);
   IParam.regItem("wwgYMesh","wwgYMesh",3,125);
-  IParam.regItem("wwgZMesh","wwgZMesh",3,125);  
-  
+  IParam.regItem("wwgZMesh","wwgZMesh",3,125);
+
   IParam.regDefItem<std::string>("X","xmlout",1,"Model.xml");
   IParam.regMulti("x","xml",10000,1);
 
@@ -243,7 +243,7 @@ createInputs(inputParam& IParam)
   IParam.setDesc("imp","Importance regions");
   IParam.setDesc("m","Create multiple files (diff: RNDseed)");
   IParam.setDesc("matDB","Set the material database to use "
-                 "(shielding or neutronics)");  
+                 "(shielding or neutronics)");
   IParam.setDesc("matFile","Set the materials from a file");
 
   IParam.setDesc("M","Add mesh tally");
@@ -257,7 +257,7 @@ createInputs(inputParam& IParam)
   IParam.setDesc("noVariables","NO variables to written to file");
   IParam.setDesc("MCNP","MCNP version");
   IParam.setDesc("FLUKA","FLUKA output");
-  IParam.setDesc("PovRay","PovRay output");
+  IParam.setDesc("POVRAY","POV-Ray output");
   IParam.setDesc("PHITS","PHITS output");
   IParam.setDesc("Monte","MonteCarlo capable simulation");
   IParam.setDesc("Mag","Activate magnetic field [Vector]");
@@ -278,8 +278,8 @@ createInputs(inputParam& IParam)
   IParam.setDesc("sdefVoid","Remove sdef card [to use source.F]");
   IParam.setDesc("sdefSource","Extra data for source.F");
   IParam.setDesc("singleItem","Single item for singleItem method");
-  
-  IParam.setDesc("physModel","Physics Model"); 
+
+  IParam.setDesc("physModel","Physics Model");
   IParam.setDesc("T","Tally type [set to -1 to see all help]");
   IParam.setDesc("TC","Tally cells for a f4 cinder tally");
   //  IParam.setDesc("TNum","Tally ");
@@ -322,7 +322,7 @@ createInputs(inputParam& IParam)
   IParam.setDesc("weightControl","Sets: energyCut scaleFactor minWeight");
   IParam.setDesc("wwgNorm"," normalization step : "
 		 "[weightRange - lowRange - highRange - powerRange]");
-  
+
   IParam.setDesc("x","XML input file");
   IParam.setDesc("X","XML output file");
   return;
@@ -349,7 +349,7 @@ createSiliconInputs(inputParam& IParam)
   IParam.setDesc("bias","");
   IParam.setDesc("detSize","Width/Height of the area-detector");
   IParam.setDesc("lambda","Wavelength in angstrom");
-  IParam.setDesc("material","Moderator material");  
+  IParam.setDesc("material","Moderator material");
   IParam.setDesc("silicon","Silicon vane material");
   IParam.setDesc("nps","Number of simulated points");
   IParam.setDesc("output","Output file");
@@ -357,7 +357,7 @@ createSiliconInputs(inputParam& IParam)
   return;
 }
 
-void 
+void
 createSinbadInputs(inputParam& IParam)
   /*!
     Set the specialise inputs for sinbad
@@ -367,7 +367,7 @@ createSinbadInputs(inputParam& IParam)
   ELog::RegMethod RegA("MainInputs[F]","createSinbadInputs");
 
   createInputs(IParam);
-  IParam.setValue("sdefType",std::string("sinbad"));    
+  IParam.setValue("sdefType",std::string("sinbad"));
 
   IParam.regDefItem<std::string>("preName","preName",1,"49");
 
@@ -375,7 +375,7 @@ createSinbadInputs(inputParam& IParam)
   return;
 }
 
-void 
+void
 createDelftInputs(inputParam& IParam)
   /*!
     Set the specialise inputs
@@ -412,7 +412,7 @@ createDelftInputs(inputParam& IParam)
   IParam.setValue("sdefType",std::string("kcode"),1);
   IParam.setValue("sdefType",std::string("kcode"),2);
   IParam.setValue("sdefType",std::string("kcode"),3);
-  
+
   return;
 }
 
@@ -430,8 +430,8 @@ void createFullInputs(inputParam& IParam)
   IParam.regDefItem<int>("cf","collFlag",1,7);
   IParam.regItem("decFile","decFile",1,1);
   IParam.regDefItem<std::string>("decType","decType",1,"standard");
-  IParam.regFlag("h","horr");  
-  IParam.regFlag("orthoH","orthoH");  
+  IParam.regFlag("h","horr");
+  IParam.regFlag("orthoH","orthoH");
   IParam.regMulti("t","target",5);
   IParam.regDefItem<int>("zoomShutterGN","zoomShutterGN",1,4);
 
@@ -445,8 +445,8 @@ void createFullInputs(inputParam& IParam)
   IParam.setDesc("zoomShutterGN","Number of sections between B4C "
 		 "in zoom shutter");
 
-  IParam.setValue("targetType",std::string("t2Target"));  
-  IParam.setValue("sdefType",std::string("TS2"));  
+  IParam.setValue("targetType",std::string("t2Target"));
+  IParam.setValue("sdefType",std::string("TS2"));
   return;
 }
 
@@ -459,10 +459,10 @@ createFilterInputs(inputParam& IParam)
 {
   ELog::RegMethod RegA("MainInputs[F]","createFilterInputs");
   createInputs(IParam);
-  
+
 
   IParam.setValue("sdefType",std::string("Beam"));
-  IParam.setFlag("voidUnMask");  
+  IParam.setFlag("voidUnMask");
   return;
 }
 
@@ -476,7 +476,7 @@ createGammaInputs(inputParam& IParam)
   ELog::RegMethod RegA("MainInputs[F]","createGammaInputs");
   createInputs(IParam);
 
-  IParam.setValue("sdefType",std::string("Gamma"));  
+  IParam.setValue("sdefType",std::string("Gamma"));
   return;
 }
 
@@ -491,7 +491,7 @@ createPhotonInputs(inputParam& IParam)
   createInputs(IParam);
 
   IParam.setValue("sdefType",std::string("Laser"));
-  IParam.setFlag("voidUnMask");  
+  IParam.setFlag("voidUnMask");
   return;
 }
 
@@ -505,20 +505,20 @@ createTS1Inputs(inputParam& IParam)
   ELog::RegMethod RegA("MainInputs[F]","createTS1Inputs");
   createInputs(IParam);
 
-  IParam.regDefItem<std::string>("CH4PreType","CH4PreType",1,"Wrapper");  
+  IParam.regDefItem<std::string>("CH4PreType","CH4PreType",1,"Wrapper");
   IParam.setDesc("CH4PreType","Name of CH4 Premoderator");
-  IParam.regDefItem<std::string>("CH4ModType","CH4ModType",1,"Basic");  
+  IParam.regDefItem<std::string>("CH4ModType","CH4ModType",1,"Basic");
   IParam.setDesc("CH4ModType","Name of CH4 Moderator");
-  IParam.regDefItem<std::string>("WaterModType","WaterModType",1,"Triangle");  
+  IParam.regDefItem<std::string>("WaterModType","WaterModType",1,"Triangle");
   IParam.setDesc("WaterModType","Name of Water [top] Moderator");
-  IParam.regDefItem<std::string>("H2ModType","H2ModType",1,"Basic");  
+  IParam.regDefItem<std::string>("H2ModType","H2ModType",1,"Basic");
   IParam.setDesc("H2ModType","Name of H2 Moderator");
 
-  IParam.regFlag("BeRods","BeRods");  
+  IParam.regFlag("BeRods","BeRods");
   IParam.setDesc("BeRods","Divide the Be into rods");
 
-  IParam.setValue("sdefType",std::string("TS1"));  
-  IParam.setValue("targetType",std::string("t1PlateTarget"));  
+  IParam.setValue("sdefType",std::string("TS1"));
+  IParam.setValue("targetType",std::string("t1PlateTarget"));
 
   return;
 }
@@ -533,9 +533,9 @@ createBilbauInputs(inputParam& IParam)
   ELog::RegMethod RegA("MainInputs[F]","createBilbauInputs");
   createInputs(IParam);
 
-  //  IParam.setValue("sdefEnergy",50.0);    
-  IParam.setValue("sdefType",std::string("TS1"));  
-  
+  //  IParam.setValue("sdefEnergy",50.0);
+  IParam.setValue("sdefType",std::string("TS1"));
+
 
   return;
 }
@@ -549,8 +549,8 @@ createBNCTInputs(inputParam& IParam)
 {
   ELog::RegMethod RegA("MainInputs[F]","createSNSInputs");
   createInputs(IParam);
-  
-  IParam.setValue("sdefType",std::string("ess"));  
+
+  IParam.setValue("sdefType",std::string("ess"));
   return;
 }
 
@@ -570,7 +570,7 @@ createD4CInputs(inputParam& IParam)
   IParam.regDefItem<int>("MS","multiScat",1,0);
   IParam.setDesc("multiScat","Consider only 1 collision ");
 
-  IParam.setValue("sdefType",std::string("D4C"));  
+  IParam.setValue("sdefType",std::string("D4C"));
   //  IParam.setFlag("Monte");
   return;
 }
@@ -598,8 +598,8 @@ createCuInputs(inputParam& IParam)
 {
   ELog::RegMethod RegA("MainInputs[F]","createCutInputs");
   createInputs(IParam);
-  
-  IParam.setValue("sdefType",std::string("TS1"));    
+
+  IParam.setValue("sdefType",std::string("TS1"));
   return;
 }
 
@@ -612,8 +612,8 @@ createPipeInputs(inputParam& IParam)
 {
   ELog::RegMethod RegA("MainInputs[F]","createPipeInputs");
   createInputs(IParam);
-  
-  IParam.setValue("sdefType",std::string("Point"));    
+
+  IParam.setValue("sdefType",std::string("Point"));
   return;
 }
 
@@ -628,10 +628,10 @@ createLinacInputs(inputParam& IParam)
   createInputs(IParam);
 
   IParam.setValue("sdefType",std::string("essLinac"));
-  
+
   return;
 }
-  
+
 
 void
 createSingleItemInputs(inputParam& IParam)
@@ -645,7 +645,7 @@ createSingleItemInputs(inputParam& IParam)
   return;
 }
 
-  
+
 void
 createEPBInputs(inputParam& IParam)
   /*!
@@ -655,8 +655,8 @@ createEPBInputs(inputParam& IParam)
 {
   ELog::RegMethod RegA("MainInputs[F]","createEPBInputs");
   createInputs(IParam);
-  
-  IParam.setValue("sdefType",std::string("ess"));  
+
+  IParam.setValue("sdefType",std::string("ess"));
   return;
 }
 
@@ -669,8 +669,8 @@ createSNSInputs(inputParam& IParam)
 {
   ELog::RegMethod RegA("MainInputs[F]","createSNSInputs");
   createInputs(IParam);
-  
-  IParam.setValue("sdefType",std::string("ess"));  
+
+  IParam.setValue("sdefType",std::string("ess"));
   return;
 }
 
@@ -684,7 +684,7 @@ createMuonInputs(inputParam& IParam)
   ELog::RegMethod RegA("MainInputs[F]","createMuonInputs");
   createInputs(IParam);
 
-  IParam.setValue("sdefType",std::string("TS1EpbColl")); 
+  IParam.setValue("sdefType",std::string("TS1EpbColl"));
   return;
 }
 
@@ -696,7 +696,7 @@ createLensInputs(inputParam& IParam)
   */
 {
   ELog::RegMethod RegA("MainInputs[F]","createLensInputs");
-  
+
   createInputs(IParam);
   IParam.regMulti("TS","surfTally",1000,2,2);
   IParam.regMulti("TE","tallyEnergy",1000,1,1);

--- a/System/process/MainProcess.cxx
+++ b/System/process/MainProcess.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   process/MainProcess.cxx
  *
  * Copyright (c) 2004-2020 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -99,7 +99,7 @@ void
 activateLogging(ELog::RegMethod& RControl)
   /*!
     Sets up the Main flags for logging
-    \param RControl :: Any RegMethod 
+    \param RControl :: Any RegMethod
   */
 {  // Set up output information:
   ELog::EM.setNBasePtr(RControl.getBasePtr());
@@ -130,7 +130,7 @@ getVariables(std::vector<std::string>& Names,
     \param Names :: Initial set of values from ARGV
     \param AddValues :: -va options [new variables]
     \param Values :: -v options [existing variables]
-    \param IterVal :: Iteration variables 
+    \param IterVal :: Iteration variables
    */
 {
   ELog::RegMethod RegA("MainProcess","getVariables");
@@ -165,14 +165,14 @@ setRunTimeVariable(FuncDataBase& Control,
 		   const std::map<std::string,std::string>& VMap,
 		   const std::map<std::string,std::string>& AVMap)
   /*!
-    Set runtime variables 
+    Set runtime variables
     \param Control :: Function Data base to update
     \param VMap :: Map of variable + values
     \param AVMap :: Map of variable to add + values
    */
 {
   ELog::RegMethod RegA("MainProcess[F]","setRunTimeVariable");
-  
+
   std::map<std::string,std::string>::const_iterator mc;
   for(mc=VMap.begin();mc!=VMap.end();mc++)
     {
@@ -211,7 +211,7 @@ void
 incRunTimeVariable(FuncDataBase& Control,
 		   const std::map<std::string,double>& VMap)
   /*!
-    Increase runtime variables 
+    Increase runtime variables
     \param Control :: Function Data base to update
     \param VMap :: Map of variable + values
    */
@@ -245,7 +245,7 @@ renumberCells(Simulation& System,const inputParam& IParam)
 
   if (!IParam.flag("renum") && !IParam.flag("cellRange"))
     return;
-  
+
   if (IParam.flag("renum"))
     {
       std::vector<int> rOffset;
@@ -263,16 +263,16 @@ renumberCells(Simulation& System,const inputParam& IParam)
 	    (i+1<dataCnt) ? IParam.getValue<std::string>("renum",i+1) : "";
 
 	  int xOffset(0);
-	  int xRange(10000);	  
+	  int xRange(10000);
 	  i+=2;
-	  if (!StrFunc::convert(Name,xOffset) || 
+	  if (!StrFunc::convert(Name,xOffset) ||
 	      !StrFunc::convert(Range,xRange))
 	    {
 	      xOffset=System.getFirstCell(Name);
-	      xRange=System.getLastCell(Name)-xOffset;			
+	      xRange=System.getLastCell(Name)-xOffset;
 	      i--;              // using names
 	    }
-	  
+
 	  if (xOffset>0)
 	    {
 	      rOffset.push_back(xOffset);
@@ -308,9 +308,9 @@ setVariables(Simulation& System,const inputParam& IParam,
 {
   ELog::RegMethod RegA("MainProcess","setVariables");
 
-  std::map<std::string,std::string> Values;  
-  std::map<std::string,std::string> AddValues;  
-  std::map<std::string,double> IterVal;  
+  std::map<std::string,std::string> Values;
+  std::map<std::string,std::string> AddValues;
+  std::map<std::string,double> IterVal;
 
 
   for(size_t i=0;i<IParam.setCnt("xml");i++)
@@ -322,7 +322,7 @@ setVariables(Simulation& System,const inputParam& IParam,
   mainSystem::getVariables(Names,AddValues,Values,IterVal);
   mainSystem::setRunTimeVariable(System.getDataBase(),Values,AddValues);
 
-  if (IParam.flag("xmlout")) 
+  if (IParam.flag("xmlout"))
     {
       ELog::EM<<"Xout == "<<IParam.getValue<std::string>("xmlout")
 	      <<ELog::endCrit;
@@ -371,7 +371,7 @@ createSimulation(inputParam& IParam,
 		 std::string& Oname)
   /*!
     Creates the simulation and populates the variables
-    \param IParam :: Input Parameter 
+    \param IParam :: Input Parameter
     \param Names :: Vector of inputs
     \param Oname :: output file name
     \return Simulation type
@@ -391,7 +391,7 @@ createSimulation(inputParam& IParam,
   if (Oname[0]=='-')
     {
       IParam.writeDescription(ELog::EM.Estream());
-      ELog::EM<<ELog::endDiag; 
+      ELog::EM<<ELog::endDiag;
       return 0;
     }
   // DEBUG
@@ -410,10 +410,10 @@ createSimulation(inputParam& IParam,
       masterWrite::Instance().setZero(1e-14);
       SimPtr=new SimFLUKA;
     }
-  else if (IParam.flag("PovRay"))
+  else if (IParam.flag("POVRAY"))
     SimPtr=new SimPOVRay;
   else if (IParam.flag("Monte"))
-    SimPtr=new SimMonte; 
+    SimPtr=new SimMonte;
   else
     {
       SimMCNP* SMCPtr=new SimMCNP;
@@ -423,14 +423,14 @@ createSimulation(inputParam& IParam,
 
   // OR.setObjectGroup(*SimPtr);
   // buildWorld(*SimPtr);
-  
+
   // DNF split the cells
   SimPtr->setCellDNF(IParam.getDefValue<size_t>(0,"cellDNF"));
   // CNF split the cells
   SimPtr->setCellCNF(IParam.getDefValue<size_t>(0,"cellCNF"));
 
   SimPtr->setCmdLine(cmdLine.str());        // set full command line
-  
+
   return SimPtr;
 }
 
@@ -448,7 +448,7 @@ InputModifications(Simulation* SimPtr,inputParam& IParam,
   ELog::RegMethod RegA("MainProcess","InputModifications");
 
   mainSystem::setVariables(*SimPtr,IParam,Names);
-  if (!Names.empty()) 
+  if (!Names.empty())
     ELog::EM<<"Unable to understand values "<<Names[0]<<ELog::endErr;
 
   return;
@@ -464,7 +464,7 @@ setMaterialsDataBase(const inputParam& IParam)
   ELog::RegMethod RegA("MainProcess","setMaterialsDataBase");
 
   const std::string materials=IParam.getValue<std::string>("matDB");
-  
+
   // Add extra materials to the DBMaterials
   if (materials=="neutronics")
     ModelSupport::addESSMaterial();
@@ -480,7 +480,7 @@ setMaterialsDataBase(const inputParam& IParam)
 	" -- shielding [S.Ansell original naming]\n"
 	" -- neutronics [ESS Target division naming]"<<ELog::endDiag;
       throw ColErr::ExitAbort("help");
-    }	
+    }
   else
     throw ColErr::InContainerError<std::string>
       (materials,"Materials Data Base type");
@@ -496,7 +496,7 @@ setMaterialsDataBase(const inputParam& IParam)
     }
   return;
 }
-  
+
 void
 exitDelete(Simulation* SimPtr)
  /*!
@@ -524,7 +524,7 @@ buildFullSimFLUKA(SimFLUKA* SimFLUKAPtr,
 {
   ELog::RegMethod RegA("MainProcess[F]","buildFullSimFLUKA");
 
-  // Definitions section 
+  // Definitions section
   int MCIndex(0);
   const int multi=IParam.getValue<int>("multi");
   if (IParam.flag("noVariables"))
@@ -536,7 +536,7 @@ buildFullSimFLUKA(SimFLUKA* SimFLUKAPtr,
 
   //
   SimProcess::importanceSim(*SimFLUKAPtr,IParam);
-  
+
   //  SimProcess::inputProcessForSim(*SimMCPtr,IParam); // energy cut etc
   tallyModification(*SimFLUKAPtr,IParam);
 
@@ -574,9 +574,9 @@ buildFullSimPHITS(SimPHITS* SimPHITSPtr,
 
   ModelSupport::setDefaultPhysics(*SimPHITSPtr,IParam);
   SimPHITSPtr->prepareWrite();  // this can be deleteted??
-  
+
   phitsSystem::tallySelection(*SimPHITSPtr,IParam);
-    
+
   SimProcess::importanceSim(*SimPHITSPtr,IParam);
 
   SimProcess::inputProcessForSim(*SimPHITSPtr,IParam); // energy cut etc
@@ -607,11 +607,11 @@ buildFullSimMCNP(SimMCNP* SimMCPtr,
     \param OName :: output file name
    */
 {
-  // Definitions section 
+  // Definitions section
   int MCIndex(0);
   const int multi=IParam.getValue<int>("multi");
 
-  
+
   ModelSupport::setDefaultPhysics(*SimMCPtr,IParam);
   SimMCPtr->prepareWrite();
 
@@ -650,7 +650,7 @@ buildFullSimPOVRay(SimPOVRay* SimPOVRayPtr,
    */
 {
   ELog::RegMethod RegA("MainProcess[F]","buildFullSimFLUKA");
-  // Definitions section 
+  // Definitions section
 
   // if (IParam.flag("noVariables"))
   //   SimPOVRayPtr->setNoVariables();
@@ -680,7 +680,7 @@ buildFullSimulation(Simulation* SimPtr,
 
   SimPtr->removeComplements();
   SimPtr->removeDeadSurfaces();
-  
+
   ModelSupport::setDefRotation(*SimPtr,IParam);
   SimPtr->masterRotation();
 
@@ -698,7 +698,7 @@ buildFullSimulation(Simulation* SimPtr,
       buildFullSimMCNP(SimMCPtr,IParam,OName);
       return;
     }
-  
+
   SimFLUKA* SimFLUKAPtr=dynamic_cast<SimFLUKA*>(SimPtr);
   if (SimFLUKAPtr)
     {
@@ -708,20 +708,19 @@ buildFullSimulation(Simulation* SimPtr,
 
   SimPOVRay* SimPOVPtr=dynamic_cast<SimPOVRay*>(SimPtr);
   if (SimPOVPtr)
-    {      
+    {
       buildFullSimPOVRay(SimPOVPtr,IParam,OName);
       return;
     }
 
   SimPHITS* SimPHITSPtr=dynamic_cast<SimPHITS*>(SimPtr);
   if (SimPHITSPtr)
-    {      
+    {
       buildFullSimPHITS(SimPHITSPtr,IParam,OName);
       return;
     }
- 
+
   return;
 }
-                      
-}  // NAMESPACE mainSystem
 
+}  // NAMESPACE mainSystem


### PR DESCRIPTION
We have the `-povray` and `-fluka` arguments to generate POV-Ray / FLUKA output, but to generate PHITS output the argument is `-p`, which does not look logical. This PR suggests to change it to `-phits`.

In the same way, the long versions for FLUKA and PHITS are `--FLUKA` and `--PHITS`, but for POVRAY it's `--PovRay`. I suggest to change it to `--POVRAY`.