### PR TITLE
Tally names

### DIFF
--- a/Main/maxiv.cxx
+++ b/Main/maxiv.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   Main/maxiv.cxx
  *
  * Copyright (c) 2004-2024 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -60,7 +60,7 @@
 
 ///\cond STATIC
 
-namespace ELog 
+namespace ELog
 {
   ELog::OutputLog<EReport> EM;
   ELog::OutputLog<FileReport> RN("Renumber.txt");   ///< Renumber
@@ -68,7 +68,7 @@ namespace ELog
 }
 ///\endcond STATIC
 
-int 
+int
 main(int argc,char* argv[])
 {
   int exitFlag(0);                // Value on exit
@@ -76,7 +76,7 @@ main(int argc,char* argv[])
   mainSystem::activateLogging(RControl);
 
   std::string Oname;
-  std::vector<std::string> Names;  
+  std::vector<std::string> Names;
 
   Simulation* SimPtr(0);
   try
@@ -114,17 +114,16 @@ main(int argc,char* argv[])
       SimPtr->objectGroups::write("ObjectRegister.txt",
 				  IParam.flag("fullOR"));
     }
-  
+
   catch (ColErr::ExitAbort& EA)
     {
       if (!EA.pathFlag())
-	ELog::EM<<"Exiting from "<<EA.what()<<ELog::endCrit;
+	ELog::EM<<"Exiting from: "<<EA.what()<<ELog::endCrit;
       exitFlag=-2;
     }
   catch (ColErr::ExBase& A)
     {
-      ELog::EM<<"EXCEPTION FAILURE :: "
-	      <<A.what()<<ELog::endCrit;
+      ELog::EM<<"EXCEPTION FAILURE: "<<A.what()<<ELog::endCrit;
       exitFlag= -1;
     }
   catch (...)

--- a/System/flukaPhysics/flukaPhysics.cxx
+++ b/System/flukaPhysics/flukaPhysics.cxx
@@ -111,45 +111,45 @@ flukaPhysics::flukaPhysics() :
     }),
 
   formatMap({
-      { "lowbias", unitTYPE(0," %2 0.0 - R0 R1 1.0 ") },
-      { "elecnucl", unitTYPE(1,"1.0 - - M0 M1 1.0 ") },
-      { "emfray", unitTYPE(0,"4.0 R0 R1 1.0 - - ") },
+      { "lowbias", unitTYPE(0," %2 0 - R0 R1 1 ") },
+      { "elecnucl", unitTYPE(1,"1 - - M0 M1 1 ") },
+      { "emfray", unitTYPE(0,"4 R0 R1 1 - - ") },
 
-      { "bias", unitTYPE(0,"%2 %3 %4 R0 R1 1.0 ") },
-      { "bias-user", unitTYPE(0,"%2 %3 %4 R0 R1 1.0 ") },
-      { "bias-off", unitTYPE(0,"%2 1.0 1.0 R0 R1 1.0 ") },
-      { "coalescence", unitTYPE(-100,"1.0 - - - - - ") },
-      { "ionsplit", unitTYPE(1,"1.0 0.1 5.0 2 500 1.0 ") },
-      { "exptrans", unitTYPE(0," 1.0 %2 R0 R1 1.0 - ") },
-      { "exppart", unitTYPE(0," -1.0 %2 %2 1.0 - - ") },
+      { "bias", unitTYPE(0,"%2 %3 %4 R0 R1 1 ") },
+      { "bias-user", unitTYPE(0,"%2 %3 %4 R0 R1 1 ") },
+      { "bias-off", unitTYPE(0,"%2 1 1 R0 R1 1 ") },
+      { "coalescence", unitTYPE(-100,"1 - - - - - ") },
+      { "ionsplit", unitTYPE(1,"1 0.1 5 2 500 1 ") },
+      { "exptrans", unitTYPE(0," 1 %2 R0 R1 1 - ") },
+      { "exppart", unitTYPE(0," -1 %2 %2 1 - - ") },
 
-      { "emfcut", unitTYPE(0,"%2 %3 0.0 R0 R1 1.0") },
-      { "emffluo", unitTYPE(1,"%2 M0 M1 1.0 - - ") },
-      { "evaporation", unitTYPE(-100,"3.0 - - - - - ") },
-      { "evap-noheavy", unitTYPE(-100,"2.0 - - - - - ") },
+      { "emfcut", unitTYPE(0,"%2 %3 0 R0 R1 1") },
+      { "emffluo", unitTYPE(1,"%2 M0 M1 1 - - ") },
+      { "evaporation", unitTYPE(-100,"3 - - - - - ") },
+      { "evap-noheavy", unitTYPE(-100,"2 - - - - - ") },
 
-      { "prodcut", unitTYPE(1,"%2 %3 1.0 M0 M1 1.0") },
-      { "photthr", unitTYPE(1,"%2 %3 %4 M0 M1 1.0") },
-      { "pho2thr", unitTYPE(1,"%2 %3 -  M0 M1 1.0") },
-      { "elpothr", unitTYPE(1,"%2 %3 %4 M0 M1 1.0") },
-      { "pairbrem", unitTYPE(1,"3.0 %2 %3 M0 M1 1.0") },
-      { "photonuc", unitTYPE(1,"1.0 - - M0 M1 1.0 ") },
-      { "mupair", unitTYPE(1,"1111.0 - - M0 M1 1.0 ") },
-      { "muphoton", unitTYPE(1,"1.0 - - M0 M1 1.0 ") },
-      { "mulsopt", unitTYPE(1,"%2 %3 %4 M0 M1 1.0 ") },
-      { "lpb", unitTYPE(0,"1022 %2 %3 R0 R1 1.0 ") },
-      { "lambbrem", unitTYPE(1,"%2 0.0 %3 M0 M1 1.0 ") },
-      { "lambemf", unitTYPE(1,"%2 %3 %4 M0 M1 1.0 ") },
+      { "prodcut", unitTYPE(1,"%2 %3 1 M0 M1 1") },
+      { "photthr", unitTYPE(1,"%2 %3 %4 M0 M1 1") },
+      { "pho2thr", unitTYPE(1,"%2 %3 -  M0 M1 1") },
+      { "elpothr", unitTYPE(1,"%2 %3 %4 M0 M1 1") },
+      { "pairbrem", unitTYPE(1,"3 %2 %3 M0 M1 1") },
+      { "photonuc", unitTYPE(1,"1 - - M0 M1 1 ") },
+      { "mupair", unitTYPE(1,"1111 - - M0 M1 1 ") },
+      { "muphoton", unitTYPE(1,"1 - - M0 M1 1 ") },
+      { "mulsopt", unitTYPE(1,"%2 %3 %4 M0 M1 1 ") },
+      { "lpb", unitTYPE(0,"1022 %2 %3 R0 R1 1 ") },
+      { "lambbrem", unitTYPE(1,"%2 0 %3 M0 M1 1 ") },
+      { "lambemf", unitTYPE(1,"%2 %3 %4 M0 M1 1 ") },
 
-      { "lamlength", unitTYPE(-1,"0.0 %2 M1 P0 P0 1.0 ") },
-      { "lamprimary", unitTYPE(-1,"0.0 %2 M1 P0 P0 1.0 ") },
+      { "lamlength", unitTYPE(-1,"0 %2 M1 P0 P0 1 ") },
+      { "lamprimary", unitTYPE(-1,"0 %2 M1 P0 P0 1 ") },
 
-      { "gas", unitTYPE(1," %2 0.0 0.0 M0 M1 1.0 ") },
-      { "rho", unitTYPE(1," 0.0 %2 0.0 M0 M1 1.0 ") },
+      { "gas", unitTYPE(1," %2 0 0 M0 M1 1 ") },
+      { "rho", unitTYPE(1," 0 %2 0 M0 M1 1 ") },
 
-      { "partthr", unitTYPE(-1,"%2 P0 P1 1.0 0.0 -") },
+      { "partthr", unitTYPE(-1,"%2 P0 P1 1 0 -") },
 
-      { "stepsize", unitTYPE(0,"%2 %3 M0 M1 1.0 - ") }
+      { "stepsize", unitTYPE(0,"%2 %3 M0 M1 1 - ") }
 
     })
 

--- a/System/flukaProcess/plotGeom.cxx
+++ b/System/flukaProcess/plotGeom.cxx
@@ -1,9 +1,9 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaProcess/plotGeom.cxx
  *
- * Copyright (c) 2004-2021 by Stuart Ansell
+ * Copyright (c) 2004-2024 by Stuart Ansell
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -42,7 +42,7 @@
 
 namespace flukaSystem
 {
-  
+
 plotGeom::plotGeom() :
   title("Basic plot"),matRegion(1)
   /*!
@@ -50,7 +50,7 @@ plotGeom::plotGeom() :
   */
 {}
 
-plotGeom::plotGeom(const plotGeom& A) : 
+plotGeom::plotGeom(const plotGeom& A) :
   title(A.title),APoint(A.APoint),BPoint(A.BPoint),
   xUnit(A.xUnit),yUnit(A.yUnit),matRegion(A.matRegion)
   /*!
@@ -86,7 +86,7 @@ plotGeom::~plotGeom()
 {}
 
 
-void 
+void
 plotGeom::setBox(const Geometry::Vec3D& APt,
 		 const Geometry::Vec3D& BPt)
   /*!
@@ -143,7 +143,7 @@ plotGeom::write(std::ostream& OX) const
 {
   std::ostringstream cx;
 
-  cx<<"PLOTGEOM 0.0 "<<matRegion<<" 0.0 0.0 79.0 0.0";
+  cx<<"PLOTGEOM 0 "<<matRegion<<" 0 0 79.0 0";
   StrFunc::writeFLUKA(cx.str(),OX);
   OX<<" "<<title.substr(0,78)<<"\n";
 
@@ -153,7 +153,7 @@ plotGeom::write(std::ostream& OX) const
   cx.str("");
   cx<<xUnit<<" "<<yUnit;
   StrFunc::writeFLUKA(cx.str(),OX);
-  StrFunc::writeFLUKA("1.0 1.0 0.0",OX); 
+  StrFunc::writeFLUKA("1 1 0",OX);
   return;
 }
 

--- a/System/flukaTally/flukaTally.cxx
+++ b/System/flukaTally/flukaTally.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTally/flukaTally.cxx
  *
  * Copyright (c) 2004-2021 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -61,34 +61,20 @@ operator<<(std::ostream& OX,const flukaTally& TX)
   return OX;
 }
 
-std::string
-flukaTally::idForm(const std::string& baseName,const int A)
-  /*!
-    Calculate the id form based on making a unique two digit char
-    \param baseName :: Prename
-    \param A :: index to used
-   */
-{
-  if (A<100) return baseName.substr(0,4)+std::to_string(A);
-
-  return baseName.substr(0,3)+std::to_string(A);
-
-}
-
-  
 flukaTally::flukaTally(const std::string& MK,
 		       const int indexID,
 		       const int outID)  :
-  keyName(idForm(MK,std::abs(indexID))),
   ID(std::abs(indexID)),
   outputUnit(outID)
   /*!
-    Constructor 
+    Constructor
     \param MK :: Keyname
     \param indexID :: flukaTally ID number
     \param outID :: flukaTally fortran tape number
   */
-{}
+{
+  setKeyName((indexID==0) ? MK : MK+std::to_string(indexID));
+}
 
 flukaTally::flukaTally(const flukaTally& A)  :
   keyName(A.keyName),
@@ -112,9 +98,9 @@ flukaTally::clone() const
 }
 
 flukaTally&
-flukaTally::operator=(const flukaTally& A) 
+flukaTally::operator=(const flukaTally& A)
   /*!
-    Assignment operator 
+    Assignment operator
     \param A :: flukaTally object to copy
     \return *this
   */
@@ -178,7 +164,7 @@ void
 flukaTally::setAuxParticles(const std::string& P)
   /*!
     Set the auxParticle [can be a range?]
-    \param P :: auxParticle (or key name) 
+    \param P :: auxParticle (or key name)
   */
 {
   auxParticle=P;
@@ -224,7 +210,7 @@ flukaTally::setAngle(const bool,const double,
    Null op call for non-angle detectors
  */
 {}
-  
+
 void
 flukaTally::setDoseType(const std::string& P,
 			const std::string& D)
@@ -243,7 +229,7 @@ flukaTally::setDoseType(const std::string& P,
       "AMB74","AMBGS"
       });
   const flukaGenParticle& FG=flukaGenParticle::Instance();
-  
+
   auxParticle=StrFunc::toUpperString(FG.nameToFLUKA(P));
    const std::string Dupper=StrFunc::toUpperString(D);
   if (validDose.find(Dupper)==validDose.end())
@@ -252,11 +238,11 @@ flukaTally::setDoseType(const std::string& P,
   doseType=Dupper;
   return;
 }
-  
+
 void
 flukaTally::writeAuxScore(std::ostream&) const
   /*!
-    Writes out the flukaTally depending on the 
+    Writes out the flukaTally depending on the
     fields that have been set.
     \param OX :: Output Stream
   */
@@ -267,7 +253,7 @@ flukaTally::writeAuxScore(std::ostream&) const
 void
 flukaTally::write(std::ostream& OX) const
   /*!
-    Writes out the flukaTally depending on the 
+    Writes out the flukaTally depending on the
     fields that have been set.
     \param OX :: Output Stream
   */

--- a/System/flukaTally/flukaTally.cxx
+++ b/System/flukaTally/flukaTally.cxx
@@ -145,6 +145,10 @@ flukaTally::setKeyName(const std::string& K)
     \param K :: Keyname
   */
 {
+  const size_t length = K.length();
+  if (length>8)
+    throw ColErr::RangeError<size_t>(length, 1, 8, "Estimator name can't exceed 8 symbols: " + K);
+
   keyName=K;
   return;
 }

--- a/System/flukaTally/flukaTally.cxx
+++ b/System/flukaTally/flukaTally.cxx
@@ -147,7 +147,7 @@ flukaTally::setKeyName(const std::string& K)
 {
   const size_t length = K.length();
   if (length>8)
-    throw ColErr::RangeError<size_t>(length, 1, 8, "Estimator name can't exceed 8 symbols: " + K);
+    throw ColErr::RangeError<size_t>(length, 1, 8, "FLUKA estimator name '" + K + "' is too long.");
 
   keyName=K;
   return;

--- a/System/flukaTally/flukaTallyBuilder.cxx
+++ b/System/flukaTally/flukaTallyBuilder.cxx
@@ -75,18 +75,19 @@ tallySelection(SimFLUKA& System,
   System.populateCells();
   System.createObjSurfMap();
 
-  for(size_t i=0;i<IParam.setCnt("tally");i++)
+  const size_t ntallies = IParam.setCnt("tally");
+  for(size_t i=0;i<ntallies;i++)
     {
-      const std::string TType=
-	IParam.getValue<std::string>("tally",i,1);
-
       const size_t NItems=IParam.itemCnt("tally",i);
-      const std::string HType=(NItems>2) ?
-	IParam.getValue<std::string>("tally",i,2) : "help";
+      if (NItems==0)
+	ELog::EM << "-T needs arguments. Call '-T help' for help." << ELog::endErr;
 
-      if (TType=="help" || TType=="?")
+      const std::string tallyName=IParam.getValue<std::string>("tally",i,0);
+      const std::string TType = NItems > 1 ?  IParam.getValue<std::string>("tally",i,1) : "";
+      const std::string HType=(NItems==1) ? tallyName : TType;
+
+      if (tallyName=="help")
 	helpTallyType(HType);
-
       else if (TType=="mesh")
 	userBinConstruct::processMesh(System,IParam,i);
       else if (TType=="dump")
@@ -120,22 +121,26 @@ helpTallyType(const std::string& HType)
 {
   ELog::RegMethod("flukaTallBuilder[F]","helpTallyType");
 
-  if (HType=="mesh")
-    {}
+  if (HType=="surface")
+    userBdxConstruct::writeHelp(ELog::EM.Estream());
+  else if (HType=="resnuclei")
+    resnucConstruct::writeHelp(ELog::EM.Estream());
   else
     {
-      ELog::EM<<"Tally Types:\n\n"
-	      <<"-- mesh : \n"
-	      <<"-- dump : \n"
-	      <<"-- surface : \n"
-	      <<"-- cell :  particle FC index eMin eMax NE \n"
-	      <<"-- raddecay : \n"
-	      <<"-- resnuc : \n"
-	      <<"-- track :  particle FC index eMin eMax NE \n";
-
+      ELog::EM << "The '-T' flag adds an estimator into the model.\n"
+	"Usage: -T estimatorName estimatorType parameters\n"
+	"       run '-T help estimatorType to display type-based help.\n\n"
+	"List of supported FLUKA estimators:\n\n"
+	"* mesh (USRBIN)\n"
+	"* dump (USERDUMP)\n"
+	"* raddecay\n"
+	"* surface (USRBDX)\n"
+	"* track (USRTRACK)\n"
+	"* resnuclei (RESNUCLEI)\n"
+	"* yield (USRYIELD)\n";
     }
-
   ELog::EM<<ELog::endBasic;
+
   return;
 }
 

--- a/System/flukaTally/flukaTallyBuilder.cxx
+++ b/System/flukaTally/flukaTallyBuilder.cxx
@@ -1,9 +1,9 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTally/flukaTallyBuilder.cxx
  *
- * Copyright (c) 2004-2023 by Stuart Ansell
+ * Copyright (c) 2004-2024 by Stuart Ansell
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -71,22 +71,22 @@ tallySelection(SimFLUKA& System,
   */
 {
   ELog::RegMethod RegA("flukaTallyBuilder[F]","tallySelection(basic)");
-  
+
   System.populateCells();
   System.createObjSurfMap();
-  
+
   for(size_t i=0;i<IParam.setCnt("tally");i++)
     {
       const std::string TType=
-	IParam.getValue<std::string>("tally",i,0);
-      
+	IParam.getValue<std::string>("tally",i,1);
+
       const size_t NItems=IParam.itemCnt("tally",i);
-      const std::string HType=(NItems>1) ?
-	IParam.getValue<std::string>("tally",i,1) : "help";
+      const std::string HType=(NItems>2) ?
+	IParam.getValue<std::string>("tally",i,2) : "help";
 
       if (TType=="help" || TType=="?")
 	helpTallyType(HType);
-      
+
       else if (TType=="mesh")
 	userBinConstruct::processMesh(System,IParam,i);
       else if (TType=="dump")
@@ -107,12 +107,12 @@ tallySelection(SimFLUKA& System,
     }
   //if (IParam.flag("Txml"))
     //   tallySystem::addXMLtally(System,IParam.getValue<std::string>("Txml"));
-      
+
   return;
 }
 
-void  
-helpTallyType(const std::string& HType) 
+void
+helpTallyType(const std::string& HType)
   /*!
     Simple help for types
     \param HType :: specialization if present that help is required for
@@ -134,7 +134,7 @@ helpTallyType(const std::string& HType)
 	      <<"-- track :  particle FC index eMin eMax NE \n";
 
     }
-  
+
   ELog::EM<<ELog::endBasic;
   return;
 }

--- a/System/flukaTally/flukaTallyBuilder.cxx
+++ b/System/flukaTally/flukaTallyBuilder.cxx
@@ -97,7 +97,7 @@ tallySelection(SimFLUKA& System,
 	userBdxConstruct::processBDX(System,IParam,i);
       else if (TType=="track" || TType=="cell")
 	userTrackConstruct::processTrack(System,IParam,i);
-      else if (TType=="resnuc")
+      else if (TType=="resnuclei")
 	resnucConstruct::processResNuc(System,IParam,i);
       else if (TType=="yield")
 	userYieldConstruct::processYield(System,IParam,i);

--- a/System/flukaTally/flukaTallySelector.cxx
+++ b/System/flukaTally/flukaTallySelector.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTally/flukaTallySelector.cxx
  *
  * Copyright (c) 2004-2023 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -66,7 +66,7 @@ tallyModification(SimFLUKA& System,
 {
   ELog::RegMethod RegA("flukaTallySelector[F]","tallyModification");
   const size_t nP=IParam.setCnt("TMod");
-	  	
+
   for(size_t i=0;i<nP;i++)
     {
       std::vector<std::string> StrItem;
@@ -82,7 +82,7 @@ tallyModification(SimFLUKA& System,
       if(key=="help")
 	{
 	  ELog::EM<<"TMod Help "
-	    "  -- userName :: tallyName/Number ExternalaName \n"
+	    "  -- userName :: tallyName/Number USRICALL_SDUM \n"
 	    "  -- ascii :: tallyName/Number \n"
 	    "  -- binary :: tallyName/Number \n"
 	    "  -- particle ::tallyName/Number particle \n"
@@ -94,7 +94,7 @@ tallyModification(SimFLUKA& System,
 		  <<ELog::endErr;
           return;
 	}
-      
+
       if(key=="ascii")
         {
 	  const std::string tName=IParam.getValueError<std::string>
@@ -167,5 +167,3 @@ tallyModification(SimFLUKA& System,
     }
   return;
 }
-
-

--- a/System/flukaTally/flukaTallySelector.cxx
+++ b/System/flukaTally/flukaTallySelector.cxx
@@ -50,10 +50,7 @@
 #include "Simulation.h"
 #include "SimFLUKA.h"
 
-
 #include "flukaTallyModification.h"
-
-
 
 void
 tallyModification(SimFLUKA& System,

--- a/System/flukaTally/radDecay.cxx
+++ b/System/flukaTally/radDecay.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTally/radDecay.cxx
  *
  * Copyright (c) 2004-2022 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -56,7 +56,7 @@ radDecay::radDecay() :
   */
 {}
 
-radDecay::radDecay(const radDecay& A) : 
+radDecay::radDecay(const radDecay& A) :
   nReplica(A.nReplica),biasCard(A.biasCard),
   gammaTransCut(A.gammaTransCut),
   eCutEnergy(A.eCutEnergy),pCutEnergy(A.pCutEnergy),
@@ -113,7 +113,7 @@ radDecay::setIradTime(const std::vector<double>& timeVec)
     Sets the decay time based on a given flux of primary particle
     for alternating Value : 0 : Value : 0 etc..
     \param Flux :: Particle flux
-    \param timeVec :: vector of times 
+    \param timeVec :: vector of times
   */
 {
   ELog::RegMethod RegA("radDecay","setIradTime");
@@ -124,7 +124,7 @@ radDecay::setIradTime(const std::vector<double>& timeVec)
       iradTime.push_back(std::pair<double,double>(DT,iradFlux * current));
       current= 1-current;
     }
-  
+
   return;
 }
 
@@ -135,7 +135,7 @@ radDecay::setDecayTime(const std::vector<double>& timeVec)
     Sets the decay time based on a given flux of primary particle
     for alternating Value : 0 : Value : 0 etc..
     \param Flux :: Particle flux
-    \param timeVec :: vector of times 
+    \param timeVec :: vector of times
   */
 {
   ELog::RegMethod RegA("radDecay","setDecayTime");
@@ -155,7 +155,7 @@ void
 radDecay::addDetectors(const std::string& TName,
 		       const size_t Index)
   /*!
-    Emplace a detector to use 
+    Emplace a detector to use
     \param TName :: Tally name [can use wildcard]
     \param Index :: Index of decay time
    */
@@ -163,12 +163,12 @@ radDecay::addDetectors(const std::string& TName,
   detectors.emplace(TName,Index);
   return;
 }
-  
+
 void
 radDecay::write(const SimFLUKA& System,
 		std::ostream& OX) const
   /*!
-    Write out decay information			
+    Write out decay information
     \param System :: Simulation for additional tallies
     \param OX :: Output stream
    */
@@ -178,21 +178,21 @@ radDecay::write(const SimFLUKA& System,
       std::ostringstream cx;
 
       if (pCutEnergy<0.0 && eCutEnergy<0.0)
-	cx<<"RADDECAY 1.0 1.0 "<<nReplica<<" - - 1.0 ";
-      else 
+	cx<<"RADDECAY 1 1 "<<nReplica<<" - - 1 ";
+      else
 	{
 	  int pPart=static_cast<int>(pCutEnergy*10.0);
 	  int ePart=static_cast<int>(eCutEnergy*10.0);
 	  if (pPart>=100000)  pPart=99999;
 	  if (ePart>=100000)  ePart=99999;
-	  cx<<"RADDECAY 1.0 1.0 "<<nReplica<<" - "
+	  cx<<"RADDECAY 1 1 "<<nReplica<<" - "
 	    <<"%"<<std::setfill('0')
 	    <<std::setw(5)<<pPart
 	    <<std::setw(5)<<ePart
-	    <<" 1.0 ";
+	    <<" 1 ";
 	}
       StrFunc::writeFLUKA(cx.str(),OX);
-      
+
       size_t index(0);
       cx.str("");
       cx<<"IRRPROFI ";
@@ -211,8 +211,8 @@ radDecay::write(const SimFLUKA& System,
 	}
       if (index % 3)
 	StrFunc::writeFLUKA(cx.str(),OX);
-      
-      
+
+
       index=0;
       cx.str("");
       cx<<"DCYTIMES ";
@@ -241,7 +241,7 @@ radDecay::write(const SimFLUKA& System,
 		<<FPtr->getKeyName()<<" "
 		<<FPtr->getKeyName()<<" 1.0 "
 		<<FPtr->getType();
-	      StrFunc::writeFLUKA(cx.str(),OX);	      
+	      StrFunc::writeFLUKA(cx.str(),OX);
 	    }
 	}
     }
@@ -249,4 +249,3 @@ radDecay::write(const SimFLUKA& System,
 }
 
 }  // NAMESPACE flukaSystem
-

--- a/System/flukaTally/resnucConstruct.cxx
+++ b/System/flukaTally/resnucConstruct.cxx
@@ -136,6 +136,9 @@ resnucConstruct::processResNuc(SimFLUKA& System,
   const std::string tallyName=
     IParam.getValue<std::string>("tally",Index,0);
 
+  if (tallyName=="help")
+    return writeHelp(ELog::EM.Estream());
+
   const std::string objectName=
     IParam.getValueError<std::string>("tally",Index,2,"tally:objectName");
 
@@ -143,9 +146,6 @@ resnucConstruct::processResNuc(SimFLUKA& System,
     (IParam.itemCnt("tally",Index)>3) ?
     IParam.getValue<std::string>("tally",Index,3) :
     "All";
-
-  if (objectName=="help" ||  objectName=="Help")
-    return writeHelp(ELog::EM.Estream());
 
   const std::set<int> cellVec=
     System.getObjectRangeWithMat(objectName,matName);
@@ -183,7 +183,11 @@ resnucConstruct::writeHelp(std::ostream& OX)
     \param OX :: Output stream
   */
 {
-  OX<<"Definition of the RESNUCLEI estimator:\n -T name resnuc objectName[:cellName] [material]\n";
+  OX<<"RESNUCLEI estimator options:\n";
+  OX<<"* objectName[:regionName] [material]\n";
+  OX<<"  if regionName is not specified, all regions of objectName are tallied;\n";
+  OX<<"  if material is not specified, all materials of the specified regions are tallied.\n";
+  OX<<"\n Example: -T myname resnuclei MyObject:MyRegion Concrete\n";
   return;
 }
 

--- a/System/flukaTally/resnucConstruct.cxx
+++ b/System/flukaTally/resnucConstruct.cxx
@@ -136,9 +136,6 @@ resnucConstruct::processResNuc(SimFLUKA& System,
   const std::string tallyName=
     IParam.getValue<std::string>("tally",Index,0);
 
-  if (tallyName=="help")
-    return writeHelp(ELog::EM.Estream());
-
   const std::string objectName=
     IParam.getValueError<std::string>("tally",Index,2,"tally:objectName");
 

--- a/System/flukaTally/resnuclei.cxx
+++ b/System/flukaTally/resnuclei.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTally/resnuclei.cxx
  *
  * Copyright (c) 2004-2022 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -48,15 +48,6 @@ namespace flukaSystem
 int resnuclei::zOut=0;
 int resnuclei::mOut=0;
 ///\endcond STATIC
-  
-resnuclei::resnuclei(const int ID,const int outIndex) :
-  flukaTally("resn",ID,outIndex),
-  cellA(0)
-  /*!
-    Constructor
-    \param outID :: Identity number of tally [fortranOut]
-  */
-{}
 
 resnuclei::resnuclei(const std::string& KN,const int outID,
 		     const int tapeID) :
@@ -113,7 +104,7 @@ resnuclei::~resnuclei()
 
 void
 resnuclei::setZaid(const int Z,const int A)
-/*! 
+/*!
   Set the max number for range
   \param Z :: Z (charge) max
   \param A :: Atomic number
@@ -127,27 +118,26 @@ resnuclei::setZaid(const int Z,const int A)
   const int NMax=AMax-ZMax;
   if (mOut < NMax)
     mOut=NMax;               // dont thing manual correct
-  
+
   return;
 }
 
-  
+
 void
 resnuclei::write(std::ostream& OX) const
   /*!
-    Write out decay information			
+    Write out decay information
     \param System :: Simulation  tallies
     \param OX :: Output stream
    */
 {
   std::ostringstream cx;
   //  const int M=AMax-ZMax+5;
-  cx<<"RESNUCLEI  3.0 "<<outputUnit<<" "<<zOut+7<<" "<<mOut+5<<
-    " R"<<cellA<<" 1.0 ";
+  cx<<"RESNUCLEI  3 "<<outputUnit<<" "<<zOut+7<<" "<<mOut+5<<
+    " R"<<cellA<<" 1 ";
   cx<<" "<<keyName;
   StrFunc::writeFLUKA(cx.str(),OX);
   return;
 }
 
 }  // NAMESPACE flukaSystem
-

--- a/System/flukaTally/userBdx.cxx
+++ b/System/flukaTally/userBdx.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTally/userBdx.cxx
  *
  * Copyright (c) 2004-2022 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -59,7 +59,7 @@ userBdx::userBdx(const std::string& KN,const int ID,const int outID) :
   */
 {}
 
-userBdx::userBdx(const userBdx& A) : 
+userBdx::userBdx(const userBdx& A) :
   flukaTally(A),
   particle(A.particle),eLogFlag(A.eLogFlag),aLogFlag(A.aLogFlag),
   fluenceFlag(A.fluenceFlag),oneDirFlag(A.oneDirFlag),
@@ -99,7 +99,7 @@ userBdx::operator=(const userBdx& A)
     }
   return *this;
 }
-  
+
 userBdx*
 userBdx::clone() const
   /*!
@@ -126,7 +126,7 @@ userBdx::getLogType() const
   const int signV((eLogFlag) ? -1 : 1);
   return (aLogFlag) ?  2*signV : signV;
 }
-  
+
 void
 userBdx::setParticle(const std::string& P)
   /*!
@@ -142,7 +142,7 @@ void
 userBdx::setAngle(const bool aFlag,const double aMin,
 		  const double aMax,const size_t NA)
   /*!
-    Set the angles 
+    Set the angles
     \param aFlag :: log flag [if true]
     \param aMin :: Min angle [min 0.001 if log]
     \param aMax :: Max angle [4pi]
@@ -167,12 +167,12 @@ userBdx::setAngle(const bool aFlag,const double aMin,
   nA=NA;
   return;
 }
-  
+
 void
 userBdx::setEnergy(const bool eFlag,const double eMin,
 		   const double eMax,const size_t NE)
   /*!
-    Set the energys 
+    Set the energys
     \perem eFleg :: log fleg [if true]
     \perem eMin :: Min energy [min 0.001MeV if log]
     \perem eMax :: Max energy [MeV]
@@ -194,7 +194,7 @@ userBdx::setEnergy(const bool eFlag,const double eMin,
   eLogFlag=eFlag;
   energyA=eMin*1e-3;
   energyB=eMax*1e-3;
-    
+
   nE=NE;
   return;
 }
@@ -211,7 +211,7 @@ userBdx::setCell(const int RA,const int RB)
   cellB=RB;
   return;
 }
-  
+
 void
 userBdx::write(std::ostream& OX) const
   /*!
@@ -223,16 +223,15 @@ userBdx::write(std::ostream& OX) const
 
   cx<<"USRBDX "<<getLogType()<<" "<<
     StrFunc::toUpperString(particle)<<" ";
-  cx<<getOutUnit()<<" R"<<cellA<<" R"<<cellB<<" 1.0 ";
+  cx<<getOutUnit()<<" R"<<cellA<<" R"<<cellB<<" "<<1.0<<" ";
   cx<<keyName;
   StrFunc::writeFLUKA(cx.str(),OX);
 
   cx.str("");
   cx<<"USRBDX "<<energyB<<" "<<energyA<<" "<<nE<<" ";
   cx<<angleB<<" "<<angleA<<" "<<nA<<" &";
-  StrFunc::writeFLUKA(cx.str(),OX);  
+  StrFunc::writeFLUKA(cx.str(),OX);
   return;
 }
 
 }  // NAMESPACE flukaSystem
-

--- a/System/flukaTally/userBdx.cxx
+++ b/System/flukaTally/userBdx.cxx
@@ -223,7 +223,7 @@ userBdx::write(std::ostream& OX) const
 
   cx<<"USRBDX "<<getLogType()<<" "<<
     StrFunc::toUpperString(particle)<<" ";
-  cx<<getOutUnit()<<" R"<<cellA<<" R"<<cellB<<" "<<1.0<<" ";
+  cx<<getOutUnit()<<" R"<<cellA<<" R"<<cellB<<" 1 ";
   cx<<keyName;
   StrFunc::writeFLUKA(cx.str(),OX);
 

--- a/System/flukaTally/userBdx.cxx
+++ b/System/flukaTally/userBdx.cxx
@@ -160,6 +160,9 @@ userBdx::setAngle(const bool aFlag,const double aMin,
     throw ColErr::RangeError<double>(aMin,minV,4*M_PI,"aMin out of range");
   if (NA<minN)
     throw ColErr::SizeError<size_t>(NA,minN,"NA to small");
+  if (aMin>=aMax)
+    throw ColErr::OrderError<double>(aMin,aMax,"aMin >= aMax");
+
 
   aLogFlag=aFlag;
   angleA=aMin;
@@ -174,22 +177,24 @@ userBdx::setEnergy(const bool eFlag,const double eMin,
   /*!
     Set the energys
     \perem eFleg :: log fleg [if true]
-    \perem eMin :: Min energy [min 0.001MeV if log]
+    \perem eMin :: Min energy [MeV]
     \perem eMax :: Max energy [MeV]
     \perem NE :: Number of points [min 3 if log]
   */
 {
   ELog::RegMethod RegE("userBdx","setEnergy");
 
-  const double minV((eFlag) ? 1e-9 : 0.0);
+  const double minV((eFlag) ? 1e-11 : 0.0);
   const size_t minN((eFlag) ? 3 : 1);
 
-  if (eMax>1e6)
-    throw ColErr::RangeError<double>(eMax,minV,1e6,"eMax out of range");
+  if (eMax>1e7)
+    throw ColErr::RangeError<double>(eMax,minV,1e7,"eMax out of range");
   if (eMin<minV)
-    throw ColErr::RangeError<double>(eMin,minV,1e6,"eMin out of range");
+    throw ColErr::RangeError<double>(eMin,minV,1e7,"eMin out of range");
   if (NE<minN)
     throw ColErr::SizeError<size_t>(NE,minN,"NE to small");
+  if (eMin>=eMax)
+    throw ColErr::OrderError<double>(eMin,eMax,"eMin >= eMax");
 
   eLogFlag=eFlag;
   energyA=eMin*1e-3;

--- a/System/flukaTally/userBdxConstruct.cxx
+++ b/System/flukaTally/userBdxConstruct.cxx
@@ -130,6 +130,9 @@ userBdxConstruct::processBDX(SimFLUKA& System,
   const std::string tallyName=
     IParam.getValue<std::string>("tally",Index,0);
 
+  if (tallyName=="help")
+    return writeHelp(ELog::EM.Estream());
+
   const std::string particleType=
     IParam.getValueError<std::string>("tally",Index,2,"tally:ParticleType");
   const std::string FCname=
@@ -147,28 +150,25 @@ userBdxConstruct::processBDX(SimFLUKA& System,
       !constructCellMapPair(System,FCname,FCindex,cellA,cellB) &&
       !constructLinkRegion(System,FCname,FCindex,cellA,cellB) &&
       !constructSurfRegion(System,FCname,FCindex,cellA,cellB)
-      )
-    {
-      // Important because we need to correct itemIndex
-      if (constructSurfRegion(System,FCname,cellA,cellB))
-	itemIndex--;
-      else
-	throw ColErr::CommandError(FCname+" "+FCindex,"Surf Tally conversion");
-
-    }
-  ELog::EM<<"Regions connected from "<<cellA<<" to "<<cellB<<ELog::endDiag;
+      ) {
+    // Important because we need to correct itemIndex
+    if (constructSurfRegion(System,FCname,cellA,cellB))
+      itemIndex--;
+    else
+      throw ColErr::CommandError(tallyName+": "+FCname+" "+FCindex,"Surface tally conversion");
+  }
+  //  ELog::EM<< tallyName << ": regions connected from "<<cellA<<" to "<<cellB<<ELog::endDiag;
 
   // This needs to be more sophisticated
   const int nextId=System.getNextFTape();
   // energy
-  const double EA=IParam.getDefValue<double>(1e-9,"tally",Index,itemIndex++);
-  const double EB=IParam.getDefValue<double>(1000.0,"tally",Index,itemIndex++);
-  const size_t NE=IParam.getDefValue<size_t>(200,"tally",Index,itemIndex++);
+  const double EA=IParam.getDefValue<double>(1e-11,"tally",Index,itemIndex++);
+  const double EB=IParam.getDefValue<double>(3000.0,"tally",Index,itemIndex++);
+  const size_t NE=IParam.getDefValue<size_t>(100,"tally",Index,itemIndex++);
   // angle
   const double AA=IParam.getDefValue<double>(0.0,"tally",Index,itemIndex++);
   const double AB=IParam.getDefValue<double>(2*M_PI,"tally",Index,itemIndex++);
   const size_t NA=IParam.getDefValue<size_t>(1,"tally",Index,itemIndex++);
-
 
   userBdxConstruct::createTally(System,tallyName,particleType,-nextId,
 				cellA,cellB,
@@ -185,15 +185,14 @@ userBdxConstruct::writeHelp(std::ostream& OX)
     \param OX :: Output stream
   */
 {
-  OX<<
-    "-T surface \n"
-    "  particleType : name of particle / energy to tally\n"
-    "  Option A : \n"
-    "       FixedComp + linkPoint (using % to mean -ve)\n"
-    "  Option B : \n"
-    "       FixedComp:CellMap:Index (index optional) \n"
-    "  Emin EMax NE \n"
-    "  AMin AngleMax NA (all optional) \n"
+  OX << "USRBDX estimator options:\n"
+    "* particle objectName linkName    [Emin Emax NE Amin Amax NA]\n"
+    "* particle objectName surfaceName [Emin Emax NE Amin Amax NA]\n"
+    "  Emin, Emax - energy range [MeV]\n"
+    "   NE - number of energy bins\n"
+    "  Amin Amax - angular range [sr]\n"
+    "   NA - number of angular bins\n"
+    "\n Example: -T myname surface 'e+&e-' MyObject \\#front 0.001 3000 100\n"
     <<std::endl;
   return;
 }

--- a/System/flukaTally/userBdxConstruct.cxx
+++ b/System/flukaTally/userBdxConstruct.cxx
@@ -129,10 +129,6 @@ userBdxConstruct::processBDX(SimFLUKA& System,
 
   const std::string tallyName=
     IParam.getValue<std::string>("tally",Index,0);
-
-  if (tallyName=="help")
-    return writeHelp(ELog::EM.Estream());
-
   const std::string particleType=
     IParam.getValueError<std::string>("tally",Index,2,"tally:ParticleType");
   const std::string FCname=

--- a/System/flukaTally/userBin.cxx
+++ b/System/flukaTally/userBin.cxx
@@ -201,7 +201,7 @@ userBin::writeAuxScore(std::ostream& OX) const
     {
       std::ostringstream cx;
       cx<<"AUXSCORE USRBIN "<<auxParticle<<" - "<<keyName
-	<<" "<<keyName<<" - "<<doseType;
+	<<" - - "<<doseType;
       StrFunc::writeFLUKA(cx.str(),OX);
     }
   return;

--- a/System/flukaTally/userBin.cxx
+++ b/System/flukaTally/userBin.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTally/userBin.cxx
  *
  * Copyright (c) 2004-2021 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -68,7 +68,7 @@ userBin::userBin(const std::string& tallyName,
   */
 {}
 
-userBin::userBin(const userBin& A) : 
+userBin::userBin(const userBin& A) :
   flukaTally(A),
   meshType(A.meshType),particle(A.particle),
   Pts(A.Pts),minCoord(A.minCoord),
@@ -99,7 +99,7 @@ userBin::operator=(const userBin& A)
   return *this;
 }
 
-  
+
 userBin*
 userBin::clone() const
   /*!
@@ -115,7 +115,7 @@ userBin::~userBin()
     Destructor
   */
 {}
-  
+
 void
 userBin::setParticle(const std::string& P)
   /*!
@@ -142,7 +142,7 @@ userBin::setDoseType(const std::string& P,
   return;
 }
 
-  
+
 void
 userBin::setIndex(const std::array<size_t,3>& IDX)
   /*!
@@ -157,7 +157,7 @@ userBin::setIndex(const std::array<size_t,3>& IDX)
 	throw ColErr::IndexError<size_t>(IDX[i],i,"IDX[index] zero");
       Pts[i]=IDX[i];
     }
-  
+
   return;
 }
 
@@ -172,7 +172,7 @@ userBin::setCoordinates(const Geometry::Vec3D& A,
   */
 {
   ELog::RegMethod RegA("userBin","setCoordinates");
-  
+
   minCoord=A;
   maxCoord=B;
   // Add some checking here
@@ -202,12 +202,12 @@ userBin::writeAuxScore(std::ostream& OX) const
       std::ostringstream cx;
       cx<<"AUXSCORE USRBIN "<<auxParticle<<" - "<<keyName
 	<<" "<<keyName<<" - "<<doseType;
-      StrFunc::writeFLUKA(cx.str(),OX);  
+      StrFunc::writeFLUKA(cx.str(),OX);
     }
   return;
 }
 
-  
+
 void
 userBin::write(std::ostream& OX) const
   /*!
@@ -219,17 +219,17 @@ userBin::write(std::ostream& OX) const
 
   const int outputUnit(getOutUnit());
   cx<<"USRBIN "<<meshType<<" "<<particle<<" "
-    <<outputUnit<<" "<<maxCoord;  
-  cx<<" mesh"<<std::to_string(std::abs(outputUnit));
+    <<outputUnit<<" "<<maxCoord;
+  cx<<" "<<keyName;
   StrFunc::writeFLUKA(cx.str(),OX);
 
   cx.str("");
   cx<<"USRBIN "<<minCoord<<" ";
-  
+
   for(size_t i=0;i<3;i++)
     cx<<Pts[i]<<" ";
   cx<<"  & ";
-  StrFunc::writeFLUKA(cx.str(),OX);  
+  StrFunc::writeFLUKA(cx.str(),OX);
   writeAuxScore(OX);
 
   flukaTally::write(OX);
@@ -237,4 +237,3 @@ userBin::write(std::ostream& OX) const
 }
 
 }  // NAMESPACE flukaSystem
-

--- a/System/flukaTally/userTrack.cxx
+++ b/System/flukaTally/userTrack.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTally/userTrack.cxx
  *
  * Copyright (c) 2004-2021 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -69,7 +69,7 @@ userTrack::userTrack(const std::string& tallyName,
   */
 {}
 
-userTrack::userTrack(const userTrack& A) : 
+userTrack::userTrack(const userTrack& A) :
   flukaTally(A),
   particle(A.particle),eLogFlag(A.eLogFlag),fluenceFlag(A.fluenceFlag),
   oneDirFlag(A.oneDirFlag),nE(A.nE),energyA(A.energyA),
@@ -102,7 +102,7 @@ userTrack::operator=(const userTrack& A)
     }
   return *this;
 }
-  
+
 userTrack*
 userTrack::clone() const
   /*!
@@ -129,7 +129,7 @@ userTrack::getLogType() const
 {
   return (eLogFlag) ? -1 : 1;
 }
-  
+
 void
 userTrack::setParticle(const std::string& P)
   /*!
@@ -138,16 +138,16 @@ userTrack::setParticle(const std::string& P)
   */
 {
   const flukaGenParticle& FG=flukaGenParticle::Instance();
-  
+
   particle=FG.nameToFLUKA(P);
   return;
 }
-  
+
 void
 userTrack::setEnergy(const bool eFlag,const double eMin,
 		     const double eMax,const size_t NE)
   /*!
-    Set the energys 
+    Set the energys
     \parem eFleg :: log fleg [if true]
     \parem eMin :: Min energy [min 0.001MeV if log]
     \parem eMax :: Max energy [MeV]
@@ -169,7 +169,7 @@ userTrack::setEnergy(const bool eFlag,const double eMin,
   eLogFlag=eFlag;
   energyA=eMin*1e-3;
   energyB=eMax*1e-3;
-    
+
   nE=NE;
   return;
 }
@@ -184,7 +184,7 @@ userTrack::setCell(const int RA)
   cellA=RA;
   return;
 }
-  
+
 void
 userTrack::write(std::ostream& OX) const
   /*!
@@ -193,18 +193,17 @@ userTrack::write(std::ostream& OX) const
    */
 {
   std::ostringstream cx;
-  
+
   cx<<"USRTRACK "<<getLogType()<<" "<<
     StrFunc::toUpperString(particle)<<" ";
-  cx<<outputUnit<<" R"<<cellA<<" 1.0 "<<nE<<" ";
+  cx<<outputUnit<<" R"<<cellA<<" 1 "<<nE<<" ";
   cx<<keyName;
   StrFunc::writeFLUKA(cx.str(),OX);
 
   cx.str("");
   cx<<"USRTRACK "<<energyB<<" "<<energyA<<" - - - - &";
-  StrFunc::writeFLUKA(cx.str(),OX);  
+  StrFunc::writeFLUKA(cx.str(),OX);
   return;
 }
 
 }  // NAMESPACE flukaSystem
-

--- a/System/flukaTally/userTrack.cxx
+++ b/System/flukaTally/userTrack.cxx
@@ -192,7 +192,7 @@ userTrack::writeAuxScore(std::ostream& OX) const
     \param OX :: Ouput stream
   */
 {
-  ELog::EM << "TODO: fix the userTrack particle: why is it not uppercase here? " << particle << ELog::endWarn;
+  //  ELog::EM << "TODO: fix the userTrack particle: why is it not uppercase here? " << particle << ELog::endWarn;
   if (!auxParticle.empty() && (particle=="DOSE-EQ" || particle=="dose-eq")) // todo: fix (see userBin::writeAuxScore)
     {
       std::ostringstream cx;

--- a/System/flukaTally/userTrack.cxx
+++ b/System/flukaTally/userTrack.cxx
@@ -186,6 +186,24 @@ userTrack::setCell(const int RA)
 }
 
 void
+userTrack::writeAuxScore(std::ostream& OX) const
+  /*!
+    Write an auxScore card
+    \param OX :: Ouput stream
+  */
+{
+  ELog::EM << "TODO: fix the userTrack particle: why is it not uppercase here? " << particle << ELog::endWarn;
+  if (!auxParticle.empty() && (particle=="DOSE-EQ" || particle=="dose-eq")) // todo: fix (see userBin::writeAuxScore)
+    {
+      std::ostringstream cx;
+      cx<<"AUXSCORE USRTRACK "<<auxParticle<<" - "<<keyName
+        <<" - - "<<doseType;
+      StrFunc::writeFLUKA(cx.str(),OX);
+    }
+  return;
+}
+
+void
 userTrack::write(std::ostream& OX) const
   /*!
     Write out the mesh tally into the tally region
@@ -203,6 +221,8 @@ userTrack::write(std::ostream& OX) const
   cx.str("");
   cx<<"USRTRACK "<<energyB<<" "<<energyA<<" - - - - &";
   StrFunc::writeFLUKA(cx.str(),OX);
+  writeAuxScore(OX);
+
   return;
 }
 

--- a/System/flukaTally/userYield.cxx
+++ b/System/flukaTally/userYield.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTally/userYield.cxx
  *
  * Copyright (c) 2004-2021 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -68,7 +68,7 @@ userYield::userYield(const std::string& KN,const int ID,const int outID) :
   */
 {}
 
-userYield::userYield(const userYield& A) : 
+userYield::userYield(const userYield& A) :
   flukaTally(A),scoreLog(A.scoreLog),
   scoreTypeA(A.scoreTypeA),scoreTypeB(A.scoreTypeB),
   particle(A.particle),eLogFlag(A.eLogFlag),aLogFlag(A.aLogFlag),
@@ -111,7 +111,7 @@ userYield::operator=(const userYield& A)
     }
   return *this;
 }
-  
+
 userYield*
 userYield::clone() const
   /*!
@@ -138,7 +138,7 @@ userYield::getLogType() const
   const int signV((eLogFlag) ? -1 : 1);
   return (aLogFlag) ?  2*signV : signV;
 }
-  
+
 void
 userYield::setParticle(const std::string& P)
   /*!
@@ -157,7 +157,7 @@ userYield::setScoreType(const bool logFlag,
   /*!
     Set the scoring type
     \param logFlag :: log type to use for A [only]
-    \param A :: ScoreTypeA 
+    \param A :: ScoreTypeA
     \param B :: ScoreTypeB
   */
 {
@@ -171,7 +171,7 @@ void
 userYield::setAngle(const bool aFlag,const double aMin,
 		    const double aMax,const size_t NA)
   /*!
-    Set the angles 
+    Set the angles
     \param aFlag :: log flag [if true]
     \param aMin :: Min angle [min 0.001 if log]
     \param aMax :: Max angle [4pi]
@@ -196,12 +196,12 @@ userYield::setAngle(const bool aFlag,const double aMin,
   nA=NA;
   return;
 }
-  
+
 void
 userYield::setEnergy(const bool eFlag,const double eMin,
 		   const double eMax,const size_t NE)
   /*!
-    Set the energys 
+    Set the energys
     \perem eFleg :: log fleg [if true]
     \perem eMin :: Min energy [min 0.001MeV if log]
     \perem eMax :: Max energy [MeV]
@@ -223,7 +223,7 @@ userYield::setEnergy(const bool eFlag,const double eMin,
   eLogFlag=eFlag;
   energyA=eMin*1e-3;
   energyB=eMax*1e-3;
-    
+
   nE=NE;
   return;
 }
@@ -252,17 +252,17 @@ userYield::getScore(const std::string& A)
   const std::map<std::string,int> nameMap({
       {"KE",1},
 	{"Monmentum",2}});
-  
+
   int out;
   if (StrFunc::convert(A,out))
     return out;
   std::map<std::string,int>::const_iterator mc=nameMap.find(A);
   if (mc!=nameMap.end())
     return mc->second;
-  
+
   return 1;
 }
-  
+
 int
 userYield::getScoreIndex() const
   /*!
@@ -274,11 +274,11 @@ userYield::getScoreIndex() const
 
   const int iE=getScore(scoreTypeA);
   const int iA=getScore(scoreTypeA);
-  
+
 
   return iE+iA*100;
 }
-  
+
 void
 userYield::write(std::ostream& OX) const
   /*!
@@ -290,16 +290,15 @@ userYield::write(std::ostream& OX) const
 
   cx<<"USRYIELD "<<getLogType()<<" "<<
     StrFunc::toUpperString(particle)<<" ";
-  cx<<outputUnit<<" R"<<cellA<<" R"<<cellB<<" 1.0 ";
+  cx<<outputUnit<<" R"<<cellA<<" R"<<cellB<<" 1 ";
   cx<<keyName;
   StrFunc::writeFLUKA(cx.str(),OX);
 
   cx.str("");
   cx<<"USRYIELD "<<energyB<<" "<<energyA<<" "<<nE<<" ";
   cx<<angleB<<" "<<angleA<<" "<<nA<<" &";
-  StrFunc::writeFLUKA(cx.str(),OX);  
+  StrFunc::writeFLUKA(cx.str(),OX);
   return;
 }
 
 }  // NAMESPACE flukaSystem
-

--- a/System/flukaTally/userYieldConstruct.cxx
+++ b/System/flukaTally/userYieldConstruct.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTally/userYieldConstruct.cxx
  *
  * Copyright (c) 2004-2022 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -54,14 +54,15 @@
 #include "TallySelector.h"
 #include "flukaTally.h"
 #include "userYield.h"
-#include "userYieldConstruct.h" 
+#include "userYieldConstruct.h"
 
 
 namespace flukaSystem
 {
 
-void 
+void
 userYieldConstruct::createTally(SimFLUKA& System,
+				const std::string& name,
 				const std::string& PType,
 				const bool lFlag,
 				const std::string& AScore,
@@ -77,18 +78,18 @@ userYieldConstruct::createTally(SimFLUKA& System,
     in the system.
     \param System :: SimFLUKA to add tallies
     \param PType :: particle name
-    \param 
-    \param AScore :: score one 						
+    \param
+    \param AScore :: score one
     \param BScore :: score two
     \param fortranTape :: output stream
     \param CellA :: initial region
     \param CellB :: secondary region
     \param eLog :: energy in log bins
     \param aLog :: angle in log bins
-    \param Emin :: Min energy 
-    \param Emax :: Max energy 
-    \param Amin :: Min angle 
-    \param Amax :: Max angle 
+    \param Emin :: Min energy
+    \param Emax :: Max energy
+    \param Amin :: Min angle
+    \param Amax :: Max angle
     \param nE :: Number of energy bins
     \param nA :: Number of angle bins
   */
@@ -96,7 +97,7 @@ userYieldConstruct::createTally(SimFLUKA& System,
   ELog::RegMethod RegA("userYieldConstruct","createTally");
 
   const flukaGenParticle& FG=flukaGenParticle::Instance();
-    
+
   userYield UD(fortranTape,fortranTape);
 
   UD.setScoreType(lFlag,AScore,BScore);
@@ -105,7 +106,7 @@ userYieldConstruct::createTally(SimFLUKA& System,
   UD.setCell(cellA,cellB);
   UD.setEnergy(eLog,Emin,Emax,nE);
   UD.setAngle(aLog,Amin,Amax,nA);
-  
+
   System.addTally(UD);
 
   return;
@@ -115,9 +116,9 @@ userYieldConstruct::createTally(SimFLUKA& System,
 void
 userYieldConstruct::processYield(SimFLUKA& System,
 				 const mainSystem::inputParam& IParam,
-				 const size_t Index) 
+				 const size_t Index)
   /*!
-    Add BDX tally (s) as needed
+    Add USRYIELD estimator (s) as needed
     - Input:
     -- particle FixedComp index
     -- particle cellA  cellB
@@ -127,8 +128,8 @@ userYieldConstruct::processYield(SimFLUKA& System,
     \param Index :: index of the -T card
   */
 {
-  ELog::RegMethod RegA("userYieldConstruct","processBdx");
-  
+  ELog::RegMethod RegA("userYieldConstruct","processYield");
+
   const std::string particleType=
     IParam.getValueError<std::string>("tally",Index,1,"tally:ParticleType");
   const std::string yieldTypeA=
@@ -141,7 +142,7 @@ userYieldConstruct::processYield(SimFLUKA& System,
     IParam.getValueError<std::string>("tally",Index,5,"tally:linkPt/Cell");
 
   bool logFlag(1);
-  
+
   size_t itemIndex(6);
   int cellA(0);
   int cellB(0);
@@ -149,10 +150,10 @@ userYieldConstruct::processYield(SimFLUKA& System,
       (!StrFunc::convert(FCname,cellA) ||
        !StrFunc::convert(FCindex,cellB) ||
        !checkLinkCells(System,cellA,cellB) ) &&
-      
+
        !constructLinkRegion(System,FCname,FCindex,cellA,cellB)
       )
-    
+
     {
       // special class because must give regions
       itemIndex+=2;
@@ -165,33 +166,34 @@ userYieldConstruct::processYield(SimFLUKA& System,
 	throw ColErr::InContainerError<std::string>
 	  (FCname+":"+FCindex,"No connecting surface on regions");
     }
-  
-  ELog::EM<<"Regions connected from "<<cellA<<" to "<<cellB<<ELog::endDiag;  
+
+  ELog::EM<<"Regions connected from "<<cellA<<" to "<<cellB<<ELog::endDiag;
 
   // This needs to be more sophisticated
   const int nextId=System.getNextFTape();
-  
+
   const double EA=IParam.getDefValue<double>(1e-9,"tally",Index,itemIndex++);
   const double EB=IParam.getDefValue<double>(1000.0,"tally",Index,itemIndex++);
-  const size_t NE=IParam.getDefValue<size_t>(200,"tally",Index,itemIndex++); 
+  const size_t NE=IParam.getDefValue<size_t>(200,"tally",Index,itemIndex++);
 
   const double AA=IParam.getDefValue<double>(0.0,"tally",Index,itemIndex++);
   const double AB=IParam.getDefValue<double>(2*M_PI,"tally",Index,itemIndex++);
-  const size_t NA=IParam.getDefValue<size_t>(1,"tally",Index,itemIndex++); 
+  const size_t NA=IParam.getDefValue<size_t>(1,"tally",Index,itemIndex++);
 
-  
-  userYieldConstruct::createTally(System,particleType,
+
+  const std::string tally_name = "myname";
+  userYieldConstruct::createTally(System,tally_name,particleType,
 				  logFlag,yieldTypeA,yieldTypeB,
 				  -nextId,
 				  cellA,cellB,
 				  1,EA,EB,NE,
 				  0,AA,AB,NA);
-  
-  return;      
-}  
-  
+
+  return;
+}
+
 void
-userYieldConstruct::writeHelp(std::ostream& OX) 
+userYieldConstruct::writeHelp(std::ostream& OX)
   /*!
     Write out help
     \param OX :: Output stream

--- a/System/flukaTallyInc/flukaTally.h
+++ b/System/flukaTallyInc/flukaTally.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTallyInc/flukaTally.h
  *
  * Copyright (c) 2004-2023 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef flukaSystem_flukaTally_h
@@ -26,24 +26,20 @@ namespace flukaSystem
 {
 
   class auxScore;
-  
+
 /*!
   \class flukaTally
   \version 1.0
   \author S. Ansell
   \date February 2018
   \brief Holds a fluka tally object as a base class
-  
+
 */
 
 class flukaTally
 {
- private:
-
-  static std::string idForm(const std::string&,const int);  
-
  protected:
-  
+
   std::string keyName;              ///< tally name
   int ID;                           ///< ID number
   int outputUnit;                   ///< Fortran output number
@@ -54,11 +50,11 @@ class flukaTally
   std::string userName;             ///< Selected for fluscw treatment
 
  public:
-  
+
   flukaTally(const std::string&,const int,const int);
   flukaTally(const flukaTally&);
   flukaTally& operator=(const flukaTally&);
-  virtual flukaTally* clone() const; 
+  virtual flukaTally* clone() const;
   virtual ~flukaTally();
 
   /// return fluka name
@@ -83,14 +79,14 @@ class flukaTally
   int getID() const { return ID; }
   /// access out unit
   int getOutUnit() const { return outputUnit; }
-  
+
   virtual void write(std::ostream&) const;
   virtual void writeAuxScore(std::ostream&) const;
 };
 
 std::ostream&
 operator<<(std::ostream&,const flukaTally&);
-  
+
 }  // NAMESPACE flukaSystem
 
 #endif

--- a/System/flukaTallyInc/resnucConstruct.h
+++ b/System/flukaTallyInc/resnucConstruct.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTallyInc/resnucConstruct.h
  *
  * Copyright (c) 2004-2022 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef tallySystem_resnucConstruct_h
@@ -45,24 +45,23 @@ namespace flukaSystem
   \brief Constructs a surface tally for fluka
 */
 
-class resnucConstruct 
+class resnucConstruct
 {
   private:
-  
+
   /// Private constructor
   resnucConstruct() {}
 
-  static void createTally(SimFLUKA&,const int,const int,const int);
-  
+  static void createTally(SimFLUKA&,const std::string&,const int,const int,const int);
+
  public:
 
   static void processResNuc(SimFLUKA&,const mainSystem::inputParam&,
 			    const size_t);
-  
+
   static void writeHelp(std::ostream&);
 };
 
 }
 
 #endif
- 

--- a/System/flukaTallyInc/resnuclei.h
+++ b/System/flukaTallyInc/resnuclei.h
@@ -40,14 +40,13 @@ class resnuclei : public flukaTally
 
   static int zOut;     ///< Max Z number
   static int mOut;     ///< Max of N-Z
-  
+
   int AMax;            ///< Max Z of material
   int ZMax;            ///< Max A of material
   int cellA;           ///< Cell number
 
 public:
 
-  resnuclei(const int,const int);
   resnuclei(const std::string&,const int,const int);
   resnuclei(const resnuclei&);
   resnuclei* clone() const override;

--- a/System/flukaTallyInc/userBdxConstruct.h
+++ b/System/flukaTallyInc/userBdxConstruct.h
@@ -1,9 +1,9 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTallyInc/userBdxConstruct.h
  *
- * Copyright (c) 2004-2018 by Stuart Ansell
+ * Copyright (c) 2004-2024 by Stuart Ansell
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef tallySystem_userBdxConstruct_h
@@ -39,33 +39,32 @@ namespace flukaSystem
 
 /*!
   \class userBdxConstruct
-  \version 1.0
+  \version 1.1
   \author S. Ansell
   \date July 2018
   \brief Constructs a surface tally for fluka
 */
 
-class userBdxConstruct 
+class userBdxConstruct
 {
   private:
-  
+
   /// Private constructor
   userBdxConstruct() {}
 
-  static void createTally(SimFLUKA&,const std::string&,const int,
+  static void createTally(SimFLUKA&,const std::string&,const std::string&,const int,
 			  const int,const int,
 			  const bool,const double,const double,const size_t,
 			  const bool,const double,const double,const size_t);
-  
+
  public:
 
   static void processBDX(SimFLUKA&,const mainSystem::inputParam&,
 			 const size_t);
-  
+
   static void writeHelp(std::ostream&);
 };
 
 }
 
 #endif
- 

--- a/System/flukaTallyInc/userBinConstruct.h
+++ b/System/flukaTallyInc/userBinConstruct.h
@@ -1,9 +1,9 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   tallyInc/userBinConstruct.h
  *
- * Copyright (c) 2004-2018 by Stuart Ansell
+ * Copyright (c) 2004-2024 by Stuart Ansell
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef tallySystem_userBinConstruct_h
@@ -45,31 +45,31 @@ namespace flukaSystem
   \brief Constructs a mesh tally from inputParam
 */
 
-class userBinConstruct 
+class userBinConstruct
 {
   private:
-  
+
   /// Private constructor
   userBinConstruct() {}
 
   static void createTally(SimFLUKA&,
 			  const std::string&,
+			  const std::string&,
 			  const int,
 			  const Geometry::Vec3D&,const Geometry::Vec3D&,
 			  const std::array<size_t,3>&);
-  
+
 
   static std::string convertTallyType(const std::string&);
-  
+
  public:
 
   static void processMesh(SimFLUKA&,const mainSystem::inputParam&,
 			  const size_t);
-  
+
   static std::string writeHelp();
 };
 
 }
 
 #endif
- 

--- a/System/flukaTallyInc/userBinConstruct.h
+++ b/System/flukaTallyInc/userBinConstruct.h
@@ -39,7 +39,7 @@ namespace flukaSystem
 
 /*!
   \class userBinConstruct
-  \version 1.0
+  \version 1.1
   \author S. Ansell
   \date July 2012
   \brief Constructs a mesh tally from inputParam

--- a/System/flukaTallyInc/userTrack.h
+++ b/System/flukaTallyInc/userTrack.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTallyInc/userTrack.h
  *
  * Copyright (c) 2004-2021 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef flukaSystem_userTrack_h
@@ -37,7 +37,7 @@ class userTrack : public flukaTally
  private:
 
   std::string particle;             ///< particle/type
-    
+
   bool eLogFlag;                    ///< energy log flag
   bool fluenceFlag;                 ///< fluence score
   bool oneDirFlag;                  ///< one direction flag
@@ -45,29 +45,30 @@ class userTrack : public flukaTally
   size_t nE;                        ///< number of energy
   double energyA;                   ///< Energy start
   double energyB;                   ///< Energy end
-  
+
   int cellA;                        ///< start cell
 
   int getLogType() const;
-  
+
  public:
 
   userTrack(const int,const int);
   userTrack(const std::string&,const int,const int);
   userTrack(const userTrack&);
-  userTrack* clone() const override; 
+  userTrack* clone() const override;
   userTrack& operator=(const userTrack&);
   ~userTrack() override;
 
     /// return fluke name
   std::string getType() const override { return "USRTRACK"; };
-  
+
   void setParticle(const std::string&);
   void setCell(const int);
   void setEnergy(const bool,const double,
 			 const double,const size_t) override;
-  
-  void write(std::ostream&) const override;  
+
+  void writeAuxScore(std::ostream&) const override;
+  void write(std::ostream&) const override;
 };
 
 }

--- a/System/flukaTallyInc/userTrackConstruct.h
+++ b/System/flukaTallyInc/userTrackConstruct.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTallyInc/userTrackConstruct.h
  *
  * Copyright (c) 2004-2023 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef tallySystem_userTrackConstruct_h
@@ -45,28 +45,27 @@ namespace flukaSystem
   \brief Constructs a surface tally for fluka
 */
 
-class userTrackConstruct 
+class userTrackConstruct
 {
   private:
-  
+
   /// Private constructor
   userTrackConstruct() = default;
 
   static bool checkLinkCells(const Simulation&,const int,const int);
-  
-  static void createTally(SimFLUKA&,const std::string&,const int,
+
+  static void createTally(SimFLUKA&,const std::string&,const std::string&,const int,
 			  const int,
 			  const bool,const double,const double,const size_t);
-  
+
  public:
 
   static void processTrack(SimFLUKA&,const mainSystem::inputParam&,
 			   const size_t);
-  
+
   static void writeHelp(std::ostream&);
 };
 
 }
 
 #endif
- 

--- a/System/flukaTallyInc/userYield.h
+++ b/System/flukaTallyInc/userYield.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTallyInc/userYield.h
  *
  * Copyright (c) 2004-2021 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef flukaSystem_userYield_h
@@ -39,9 +39,9 @@ class userYield : public flukaTally
   bool scoreLog;                     ///< scoring A as log
   std::string scoreTypeA;            ///< scoring type A
   std::string scoreTypeB;            ///< scoring type B
-      
+
   std::string particle;             ///< particle/type
-  
+
   bool eLogFlag;                    ///< energy log flag
   bool aLogFlag;                    ///< angle log flag
   bool fluenceFlag;                 ///< fluence score
@@ -54,36 +54,36 @@ class userYield : public flukaTally
   size_t nA;                        ///< number of angle
   double angleA;                    ///< Angle start
   double angleB;                    ///< Angle end
-  
+
   int cellA;                        ///< start cell
   int cellB;                        ///< end cell
 
   static int getScore(const std::string&);
   int getLogType() const;
   int getScoreIndex() const;
-  
+
  public:
 
   userYield(const int,const int);
   userYield(const std::string&,const int,const int);
   userYield(const userYield&);
-  userYield* clone() const override; 
+  userYield* clone() const override;
   userYield& operator=(const userYield&);
   ~userYield() override;
 
   /// return fluke name
-  std::string getType() const override { return "USRBDX"; };
+  std::string getType() const override { return "USRYIELD"; };
 
   void setScoreType(const bool,const std::string&,const std::string&);
   void setParticle(const std::string&);
-    
+
   void setCell(const int,const int);
   void setAngle(const bool,const double,
 		const double,const size_t) override;
   void setEnergy(const bool,const double,
 			 const double,const size_t) override;
-  
-  void write(std::ostream&) const override;  
+
+  void write(std::ostream&) const override;
 };
 
 }

--- a/System/flukaTallyInc/userYieldConstruct.h
+++ b/System/flukaTallyInc/userYieldConstruct.h
@@ -1,9 +1,9 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   flukaTallyInc/userYieldConstruct.h
  *
- * Copyright (c) 2004-2018 by Stuart Ansell
+ * Copyright (c) 2004-2024 by Stuart Ansell
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef tallySystem_userYieldConstruct_h
@@ -39,36 +39,35 @@ namespace flukaSystem
 
 /*!
   \class userYieldConstruct
-  \version 1.0
+  \version 1.1
   \author S. Ansell
-  \date July 2018
-  \brief Constructs a surface tally for fluka
+  \date July 2024
+  \brief Constructs a USRYIELD estimator for FLUKA
 */
 
-class userYieldConstruct 
+class userYieldConstruct
 {
   private:
-  
+
   /// Private constructor
   userYieldConstruct() {}
 
-  static void createTally(SimFLUKA&,const std::string&,
+  static void createTally(SimFLUKA&,const std::string&,const std::string&,
 			  const bool lFlag,const std::string&,
 			  const std::string&,
 			  const int,
 			  const int,const int,
 			  const bool,const double,const double,const size_t,
 			  const bool,const double,const double,const size_t);
-  
+
  public:
 
   static void processYield(SimFLUKA&,const mainSystem::inputParam&,
 			   const size_t);
-  
+
   static void writeHelp(std::ostream&);
 };
 
 }
 
 #endif
- 

--- a/System/monte/Material.cxx
+++ b/System/monte/Material.cxx
@@ -887,7 +887,7 @@ Material::writeFLUKA(std::ostream& OX) const
   StrFunc::writeMCNPX(cx.str(),OX);
   cx.str("");
 
-  cx<<"MATERIAL 0.0  - "<<getMacroDensity()<<" -  -  - "<<matName<<std::endl;
+  cx<<"MATERIAL 0  - "<<getMacroDensity()<<" -  -  - "<<matName<<std::endl;
   StrFunc::writeFLUKA(cx.str(),OX);
 
   cx.str("");

--- a/System/physics/LSwitchCard.cxx
+++ b/System/physics/LSwitchCard.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   physics/LSwitchCard.cxx
 *
  * Copyright (c) 2004-2018 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -40,9 +40,9 @@
 #include "writeSupport.h"
 
 #include "LSwitchCard.h"
- 
+
 namespace physicsSystem
-{ 
+{
 
 std::ostream&
 operator<<(std::ostream& OX,const LSwitchCard& A)
@@ -65,7 +65,7 @@ LSwitchCard::LSwitchCard() :
   */
 {}
 
-LSwitchCard::LSwitchCard(const LSwitchCard& A) : 
+LSwitchCard::LSwitchCard(const LSwitchCard& A) :
   lcaActive(A.lcaActive),leaActive(A.leaActive),lcbActive(A.lcbActive),
   lcaVal(A.lcaVal),leaVal(A.leaVal),lcbVal(A.lcbVal)
   /*!
@@ -102,7 +102,7 @@ LSwitchCard::~LSwitchCard()
 {}
 
 std::vector<int>&
-LSwitchCard::getVec(const std::string& Key) 
+LSwitchCard::getVec(const std::string& Key)
   /*!
     Get a reference to the value vector
     \param Key :: Key Name
@@ -115,12 +115,12 @@ LSwitchCard::getVec(const std::string& Key)
     return leaVal;
   if (Key=="lcb")
     return lcbVal;
-  
+
   throw ColErr::InContainerError<std::string>(Key,ELog::RegMethod::getFull());
 }
 
 size_t&
-LSwitchCard::getActive(const std::string& Key) 
+LSwitchCard::getActive(const std::string& Key)
   /*!
     Get a reference to the active value
     \param Key :: Key Name
@@ -133,7 +133,7 @@ LSwitchCard::getActive(const std::string& Key)
     return leaActive;
   if (Key=="lcb")
     return lcbActive;
-  
+
   throw ColErr::InContainerError<std::string>(Key,"getActive");
 }
 
@@ -151,7 +151,7 @@ LSwitchCard::getVec(const std::string& Key) const
     return leaVal;
   if (Key=="lcb")
     return lcbVal;
-  
+
   throw ColErr::InContainerError<std::string>(Key,"LSwitchCar::getVec");
 }
 
@@ -170,17 +170,17 @@ LSwitchCard::getActive(const std::string& Key) const
     return leaVal.size();
   if (Key=="lcb")
     return lcbVal.size();
-  
+
   throw ColErr::InContainerError<std::string>
     (Key,"LSwitchCard::getActive");
 }
 
 void
-LSwitchCard::setValues(const std::string& Key,const std::string& Line) 
+LSwitchCard::setValues(const std::string& Key,const std::string& Line)
   /*!
     Set the values from a card
     \param Key :: Line to set
-    \param Line :: Line to process	       
+    \param Line :: Line to process
   */
 {
   ELog::RegMethod RegA("LSwitchCard","setValues(string)");
@@ -210,7 +210,7 @@ LSwitchCard::setValue(const std::string& Key,
 		      const int value)
   /*!
     Set a special interest in a cell ID
-    The existance of the cell is only 
+    The existance of the cell is only
     checked at the write out stage.
     \param Key :: Key name of object
     \param ID :: Cell number
@@ -222,7 +222,7 @@ LSwitchCard::setValue(const std::string& Key,
   std::vector<int>& KV=getVec(Key);
   size_t& active=getActive(Key);
   const size_t maxSize=KV.size();
-  if (ID>=maxSize) 
+  if (ID>=maxSize)
     throw ColErr::IndexError<size_t>(ID,maxSize,"ID");
   if (active<ID)
     active=ID;
@@ -242,7 +242,7 @@ LSwitchCard::getValue(const std::string& Key,
   */
 {
   ELog::RegMethod RegA("LSwitchCard","getValue");
-  
+
   const std::vector<int>& KV=getVec(Key);
   const size_t aSize=getActive(Key);
   if (ID>=aSize)
@@ -268,9 +268,9 @@ LSwitchCard::write(std::ostream& OX) const
 	  if (i!=3)
 	    cx<<lcaVal[i]<<" ";
 	  else
-	    cx<<fmt::format("{:04d}",lcaVal[i]);
+	    cx<<fmt::format("{:04d} ",lcaVal[i]);
 	}
-      StrFunc::writeMCNPX(cx.str(),OX);      
+      StrFunc::writeMCNPX(cx.str(),OX);
     }
   if (leaActive)
     {
@@ -278,7 +278,7 @@ LSwitchCard::write(std::ostream& OX) const
       cx<<"lea ";
       for(size_t i=0;i<leaActive;i++)
 	cx<<leaVal[i]<<" ";
-      StrFunc::writeMCNPX(cx.str(),OX);      
+      StrFunc::writeMCNPX(cx.str(),OX);
     }
   if (lcbActive)
     {
@@ -286,7 +286,7 @@ LSwitchCard::write(std::ostream& OX) const
       cx<<"lcb ";
       for(size_t i=0;i<lcbActive;i++)
 	cx<<lcbVal[i]<<" ";
-      StrFunc::writeMCNPX(cx.str(),OX);      
+      StrFunc::writeMCNPX(cx.str(),OX);
     }
 
   return;

--- a/System/tally/TallyBuilder.cxx
+++ b/System/tally/TallyBuilder.cxx
@@ -145,18 +145,18 @@ helpTallyType(const std::string& HType)
     sswConstruct::writeHelp(ELog::EM.Estream());
   else
     {
-      ELog::EM<<"The '-T' flag adds a tally into the model." << ELog::endBasic;
-      ELog::EM<<"Usage: -T tallyName tallyType parameters" << ELog::endBasic;
-      ELog::EM<<"       run: '-T help tallyType' to display the type-based help\n" << ELog::endBasic;
-      ELog::EM<<"Tally Types:\n\n";
-      ELog::EM<<"-- grid : \n";
-      ELog::EM<<"-- mesh (tmesh): \n";
-      ELog::EM<<"-- point (f5): \n";
-      ELog::EM<<"-- surface (f1): \n";
-      ELog::EM<<"-- flux (f4): \n";
-      ELog::EM<<"-- heat (f6): \n";
-      ELog::EM<<"-- fission : \n";
-      ELog::EM<<"-- SSW : \n";
+      ELog::EM<<"The '-T' flag adds a tally into the model.\n"
+	"Usage: -T tallyName tallyType parameters\n"
+	"       run '-T help tallyType' to display type-based help.\n\n"
+	"List of supported MCNP tallies:\n\n"
+	"* grid\n"
+	"* mesh (tmesh)\n"
+	"* point (f5)\n"
+	"* surface (f1)\n"
+	"* flux (f4)\n"
+	"* heat (f6)\n"
+	"* fission\n"
+	"* ssw\n";
     }
   ELog::EM<<ELog::endBasic;
 

--- a/System/tally/TallyBuilder.cxx
+++ b/System/tally/TallyBuilder.cxx
@@ -1,9 +1,9 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   tally/TallyBuilder.cxx
  *
- * Copyright (c) 2004-2018 by Stuart Ansell
+ * Copyright (c) 2004-2024 by Stuart Ansell / Konstantin Batkov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -70,22 +70,20 @@ tallySelection(SimMCNP& System,
 {
   ELog::RegMethod RegA("TallyBuilder","tallySelection(basic)");
 
-
-  for(size_t i=0;i<IParam.setCnt("tally");i++)
+  const size_t ntallies = IParam.setCnt("tally");
+  for(size_t i=0;i<ntallies;i++)
     {
-      const std::string TType=
-	IParam.getValue<std::string>("tally",i,0);
-      
       const size_t NItems=IParam.itemCnt("tally",i);
-      const std::string HType=(NItems>1) ?
-	IParam.getValue<std::string>("tally",i,1) : "help";
-      
-      if (TType=="help" || TType=="?")
-	helpTallyType(HType);
-      else if (HType=="help" || HType=="?")
-	helpTallyType(TType);
+      if (NItems==0)
+	ELog::EM << "-T needs arguments. Call '-T help' for help." << ELog::endErr;
 
-      else if (TType=="grid") 
+      const std::string tallyName=IParam.getValue<std::string>("tally",i,0);
+      const std::string TType = NItems > 1 ?  IParam.getValue<std::string>("tally",i,1) : "";
+      const std::string HType=(NItems==1) ? tallyName : TType;
+
+      if (tallyName=="help")
+	helpTallyType(HType);
+      else if (TType=="grid")
 	gridConstruct::processGrid(System,IParam,i);
       else if (TType=="point")
 	pointConstruct::processPoint(System,IParam,i);
@@ -108,17 +106,18 @@ tallySelection(SimMCNP& System,
       else if (TType=="SSW" || TType=="ssw")
 	sswConstruct::processSSW(System,IParam,i);
       else
-	ELog::EM<<"Unable to understand tally type :"<<TType<<ELog::endErr;
+	ELog::EM<<"Unable to understand tally type: "<<TType<<
+	  ". Call '-T help' for help." << ELog::endErr;
     }
 
   //if (IParam.flag("Txml"))
     //   tallySystem::addXMLtally(System,IParam.getValue<std::string>("Txml"));
-      
+
   return;
 }
 
-void  
-helpTallyType(const std::string& HType) 
+void
+helpTallyType(const std::string& HType)
   /*!
     Simple help for types
     \param HType :: specialization if present that help is required for
@@ -146,18 +145,21 @@ helpTallyType(const std::string& HType)
     sswConstruct::writeHelp(ELog::EM.Estream());
   else
     {
+      ELog::EM<<"The '-T' flag adds a tally into the model." << ELog::endBasic;
+      ELog::EM<<"Usage: -T tallyName tallyType parameters" << ELog::endBasic;
+      ELog::EM<<"       run: '-T help tallyType' to display the type-based help\n" << ELog::endBasic;
       ELog::EM<<"Tally Types:\n\n";
       ELog::EM<<"-- grid : \n";
-      ELog::EM<<"-- mesh : \n";
-      ELog::EM<<"-- point : \n";
-      ELog::EM<<"-- surface : \n";
-      ELog::EM<<"-- flux : \n";
-      ELog::EM<<"-- heat : \n";
+      ELog::EM<<"-- mesh (tmesh): \n";
+      ELog::EM<<"-- point (f5): \n";
+      ELog::EM<<"-- surface (f1): \n";
+      ELog::EM<<"-- flux (f4): \n";
+      ELog::EM<<"-- heat (f6): \n";
       ELog::EM<<"-- fission : \n";
       ELog::EM<<"-- SSW : \n";
     }
-  
   ELog::EM<<ELog::endBasic;
+
   return;
 }
 

--- a/System/tally/TallyCreate.cxx
+++ b/System/tally/TallyCreate.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   tally/TallyCreate.cxx
  *
  * Copyright (c) 2004-2024 by Stuart Ansell
@@ -16,17 +16,17 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <cmath>
-#include <complex> 
+#include <complex>
 #include <vector>
-#include <list> 
-#include <map> 
+#include <list>
+#include <map>
 #include <set>
 #include <string>
 #include <algorithm>
@@ -78,11 +78,11 @@
 
 namespace tallySystem
 {
-  
+
 
 void
 addF1Tally(SimMCNP& System,const int tNum,
-	   const int surfNum)
+	   const int surfNum,const std::string& comment)
   /*!
     Addition of a tally to the mcnpx
     deck
@@ -96,6 +96,7 @@ addF1Tally(SimMCNP& System,const int tNum,
   TX.addSurface(surfNum);
   TX.setEnergy("1.0e-11 251log 1e3");
   TX.setPrintField("f d u s m e t c");
+  TX.setComment(comment);
   System.addTally(TX);
 
   return;
@@ -104,7 +105,7 @@ addF1Tally(SimMCNP& System,const int tNum,
 void
 addF1Tally(SimMCNP& System,const int tNum,
 	   const int surfNum,
-	   const std::vector<int>& SDividers)
+	   const std::vector<int>& SDividers,const std::string& comment)
   /*!
     Addition of a tally to the mcnp deck
     \param System :: SimMCNP class
@@ -119,6 +120,7 @@ addF1Tally(SimMCNP& System,const int tNum,
   TX.setEnergy("1.0e-11 251log 1e3");
   TX.setPrintField("f d u s m e t c");
   TX.setSurfDivider(SDividers);
+  TX.setComment(comment);
   System.addTally(TX);
 
   return;
@@ -128,7 +130,7 @@ void
 addFullHeatBlock(SimMCNP& System)
   /*!
     Adds a f6 for everthing
-    \param System :: Simuation object 
+    \param System :: Simuation object
   */
 {
   ELog::RegMethod RegA("tallySystem","addFullHeatBlock");
@@ -157,7 +159,7 @@ void
 addHeatBlock(SimMCNP& System,const std::vector<int>& CellList)
   /*!
     Adds a f6 for designated cells
-    \param System :: Simuation object 
+    \param System :: Simuation object
     \param CellList :: Items to add unit for
   */
 {
@@ -168,10 +170,10 @@ addHeatBlock(SimMCNP& System,const std::vector<int>& CellList)
   std::vector<int> Tvalues=Units;
   copy(CellList.begin(),CellList.end(),
        std::back_inserter(Tvalues));
-  
-  // 
+
+  //
   // Get Duplicates since only non-void cells are acceptable:
-  // 
+  //
   sort(Tvalues.begin(),Tvalues.end());
   std::vector<int>::iterator vc=Tvalues.begin();
   std::vector<int> cellsActual;
@@ -204,14 +206,14 @@ addHeatBlock(SimMCNP& System,const std::vector<int>& CellList)
     }
   return;
 }
-  
+
 void
 addF4Tally(SimMCNP& System,const int tallyNum,
 	   const std::string& pType,const std::set<int>& Units)
   /*!
     Addition of a tally to the mcnpx deck
     \param System :: SimMCNP class
-    \param tallyNum :: Cell number to tally 
+    \param tallyNum :: Cell number to tally
     \param pType :: particle to tally over
     \param Units :: List of cells to add
   */
@@ -235,7 +237,7 @@ addF7Tally(SimMCNP& System,const int tallyNum,
   /*!
     Addition of a tally to the mcnpx deck
     \param System :: SimMCNP class
-    \param tallyNum :: Cell number to tally 
+    \param tallyNum :: Cell number to tally
     \param Units :: List of cells to add
   */
 {
@@ -249,18 +251,18 @@ addF7Tally(SimMCNP& System,const int tallyNum,
   return;
 }
 
-  
+
 sswTally*
 addSSWTally(SimMCNP& System)
   /*!
     Add a SSW tally to ASim [if it doesn't already have one]
-    \param System :: SimMCNP item    
+    \param System :: SimMCNP item
     \return Tally pointer
    */
 {
   sswTally TX(0);
   System.addTally(TX);
-  
+
   return System.getSSWTally();
 }
 
@@ -271,7 +273,7 @@ addF5Tally(SimMCNP& System,const int tNumber,
 	   const std::vector<Geometry::Vec3D>& VList,
 	   const double secondDistance)
   /*!
-    Adds a point tally 
+    Adds a point tally
     \param System :: SimMCNP item
     \param tNumber :: Tally Number
     \param Point :: Centre point
@@ -303,11 +305,11 @@ addF5Tally(SimMCNP& System,const int tNumber,
 
   return;
 }
-  
+
 void
 addF5Tally(SimMCNP& System,const int tNumber)
   /*!
-    Adds a point tally 
+    Adds a point tally
     \param System :: SimMCNP item
     \param tNumber :: Tally Number
   */
@@ -330,7 +332,7 @@ setComment(SimMCNP& System,const int tNumber,const std::string& Comment)
   ELog::RegMethod RegA("TallyCreate","setComment");
 
   tallySystem::pointTally* TX=
-    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber)); 
+    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber));
   if (!TX)
     ELog::EM<<"Error finding tally number "<<tNumber<<ELog::endErr;
   else
@@ -354,7 +356,7 @@ cutTallyEnergy(SimMCNP& System,const double energyCut)
   return;
 }
 
-void 
+void
 setF5Position(SimMCNP& System,const int tNumber,
 	      const Geometry::Vec3D& CPoint,const Geometry::Vec3D& Axis,
 	      const double DBplane,const double WStep)
@@ -371,7 +373,7 @@ setF5Position(SimMCNP& System,const int tNumber,
   ELog::RegMethod RegA("TallyCreate","setF5Position");
   const masterRotate& MR=masterRotate::Instance();
   tallySystem::pointTally* TX=
-    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber)); 
+    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber));
   if (!TX)
     {
       ELog::EM<<"setF5Position:: Error finding tally number "
@@ -387,7 +389,7 @@ setF5Position(SimMCNP& System,const int tNumber,
   return;
 }
 
-void 
+void
 setF5Position(SimMCNP& System,const int tNumber,
 	      const Geometry::Vec3D& TPoint)
   /*!
@@ -400,7 +402,7 @@ setF5Position(SimMCNP& System,const int tNumber,
   ELog::RegMethod RegA("TallyCreate","setF5Position(point)");
 
   tallySystem::pointTally* TX=
-    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber)); 
+    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber));
   if (!TX)
     {
       ELog::EM<<"Error finding tally number "<<tNumber<<ELog::endErr;
@@ -410,7 +412,7 @@ setF5Position(SimMCNP& System,const int tNumber,
   return;
 }
 
-void 
+void
 moveF5Tally(SimMCNP& System,const int tNumber,
 	    const Geometry::Vec3D& moveVec)
   /*!
@@ -423,7 +425,7 @@ moveF5Tally(SimMCNP& System,const int tNumber,
   ELog::RegMethod RegA("TallyCreate","moveF5Position");
 
   tallySystem::pointTally* TX=
-    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber)); 
+    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber));
   if (!TX)
     {
       ELog::EM<<"Error finding tally number "<<tNumber<<ELog::endErr;
@@ -433,7 +435,7 @@ moveF5Tally(SimMCNP& System,const int tNumber,
   return;
 }
 
-void 
+void
 setTallyTime(SimMCNP& System,const int tNumber,
 	     const std::string& timeStr)
   /*!
@@ -445,13 +447,13 @@ setTallyTime(SimMCNP& System,const int tNumber,
 {
   ELog::RegMethod RegA("TallyCreate","setTallyTime");
 
-  tallySystem::Tally* TX=System.getTally(tNumber); 
+  tallySystem::Tally* TX=System.getTally(tNumber);
   if (!TX)
     throw ColErr::InContainerError<int>(tNumber,"tally number");
 
   if (TX->setTime(timeStr))
     throw ColErr::InvalidLine(timeStr,"timeStr",0);
-  
+
   return;
 }
 
@@ -471,7 +473,7 @@ setF5Angle(SimMCNP& System,const int tNumber,
   ELog::RegMethod RegA("TallyCreate","setF5Angle");
 
   tallySystem::pointTally* TX=
-    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber)); 
+    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber));
   if (!TX)
     throw ColErr::InContainerError<int>(tNumber,"point tally number");
 
@@ -483,7 +485,7 @@ void
 widenF5Tally(SimMCNP& System,const int tNumber,
 	     const int dirIndex,const double scale)
   /*!
-    Widens the tally in the window direction by scale cm in 
+    Widens the tally in the window direction by scale cm in
     each direction
     \param System :: SimMCNP to deal with
     \param tNumber :: tally number
@@ -494,7 +496,7 @@ widenF5Tally(SimMCNP& System,const int tNumber,
   ELog::RegMethod RegA("TallyCreate","widenF5Tally");
 
   tallySystem::pointTally* TX=
-    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber)); 
+    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber));
   if (!TX)
     throw ColErr::InContainerError<int>(tNumber,"Point tally number");
 
@@ -506,7 +508,7 @@ void
 slideF5Tally(SimMCNP& System,const int tNumber,
 	     const int dirIndex,const double scale)
   /*!
-    Widens the tally in the window direction by scale cm in 
+    Widens the tally in the window direction by scale cm in
     each direction
     \param System :: SimMCNP to deal with
     \param tNumber :: tally number
@@ -538,7 +540,7 @@ shiftF5Tally(SimMCNP& System,const int tNumber,
   ELog::RegMethod RegA("TallyCreate","shiftF5Tally");
 
   tallySystem::pointTally* TX=
-    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber)); 
+    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber));
   if (!TX)
     throw ColErr::InContainerError<int>(tNumber,"Point tally number");
 
@@ -563,7 +565,7 @@ divideF5Tally(SimMCNP& System,const int tNumber,
   if (tNumber)
     {
       tallySystem::pointTally* TX=
-	dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber)); 
+	dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber));
       if (!TX)
         throw ColErr::InContainerError<int>(tNumber,"Point tally number");
       TX->divideWindow(xPts,yPts);
@@ -575,7 +577,7 @@ divideF5Tally(SimMCNP& System,const int tNumber,
       for(mc=TM.begin() ;mc!=TM.end(); mc++)
 	{
 	  tallySystem::pointTally* TX=
-	    dynamic_cast<tallySystem::pointTally*>(mc->second); 
+	    dynamic_cast<tallySystem::pointTally*>(mc->second);
 	  if (TX)
 	    TX->divideWindow(xPts,yPts);
 	}
@@ -600,7 +602,7 @@ removeF5Window(SimMCNP& System,const int tNumber)
   for( ;mc!=TM.end(); mc++)
     {
       tallySystem::pointTally* TX=
-	dynamic_cast<tallySystem::pointTally*>(mc->second); 
+	dynamic_cast<tallySystem::pointTally*>(mc->second);
       if (TX)
 	{
 	  // delete window if present
@@ -624,7 +626,7 @@ modF5TallyCells(SimMCNP& System,const int tNumber,
   ELog::RegMethod RegA("TallyCreate","modF5TallyCells");
 
   tallySystem::pointTally* TX=
-    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber)); 
+    dynamic_cast<tallySystem::pointTally*>(System.getTally(tNumber));
   if (!TX)
     throw ColErr::InContainerError<int>(tNumber,"Point tally number");
 
@@ -644,7 +646,7 @@ addF6Tally(SimMCNP& System,const int tNumber,
   /*!
     Creates a +f6 type tally
     \param System :: SimMCNP to add
-    \param tNumber :: tally number 
+    \param tNumber :: tally number
     \param particleType :: particle type
     \param cellList :: Cells to tally in
    */
@@ -670,8 +672,8 @@ writePlanes(const int Index,const int MP,
   /*!
     Diagnostic to write plane info from a point tally (ugly)
     \param Index :: Index of tally
-    \param MP :: Master Plane 
-    \param Planes :: List of planes 
+    \param MP :: Master Plane
+    \param Planes :: List of planes
   */
 {
   ELog::EM<<"Beamline ==== "<<Index<<ELog::endDiag;
@@ -715,7 +717,7 @@ deleteTally(SimMCNP& Sim,const int ID)
   /*!
     Delete a tally based on the number-type
     \param Sim :: SimMCNP system to remove tallies from
-    \param ID :: Type number to delete 
+    \param ID :: Type number to delete
   */
 {
   ELog::RegMethod RegA("TallyCreate","deleteTally");
@@ -736,12 +738,12 @@ deleteTally(SimMCNP& Sim,const int ID)
 }
 
 int
-getFarPoint(const SimMCNP& Sim,Geometry::Vec3D& Pt) 
+getFarPoint(const SimMCNP& Sim,Geometry::Vec3D& Pt)
   /*!
     Get the last tally point based on the tallynumber
     Can use the mesh centre if no point tallies exist
     \param Sim :: System to access tally tables
-    \param Pt :: Point 
+    \param Pt :: Point
     \return tally number [0 on fail]
   */
 {
@@ -759,7 +761,7 @@ getFarPoint(const SimMCNP& Sim,Geometry::Vec3D& Pt)
 	  tnum=PTptr->getKey();
 	  Pt=PTptr->getCentre();
 	}
-      else 
+      else
 	{
 	  const tmeshTally* TMptr=
 	    dynamic_cast<const tmeshTally*>(mc->second);
@@ -837,7 +839,7 @@ setSingle(SimMCNP& Sim,const int tNumber)
 	    fnum++;
 	}
     }
-  return fnum;  
+  return fnum;
 }
 
 int
@@ -914,7 +916,7 @@ setFormat(SimMCNP& System,const int tNumber,
    */
 {
   ELog::RegMethod RegA("TallyCreate","setFormat");
-  
+
   SimMCNP::TallyTYPE& tmap=System.getTallyMap();
   int fnum(0);
   SimMCNP::TallyTYPE::iterator mc;
@@ -927,7 +929,7 @@ setFormat(SimMCNP& System,const int tNumber,
 	    fnum++;
 	}
     }
-  
+
   return fnum;
 }
 
@@ -937,12 +939,12 @@ mergeTally(SimMCNP& Sim,const int aNumber,
   /*!
     Merge the tallys together into one [if makes sense]
     \param Sim :: SimMCNP
-    \param aNumber :: tally nubmer 
+    \param aNumber :: tally nubmer
     \param bNumber :: tally nubmer [-ve for type / 0 for all]
     \param  :: format string [MCNP format]
   */
 {
-  ELog::RegMethod RegA("TallyCreate","mergeTally");  
+  ELog::RegMethod RegA("TallyCreate","mergeTally");
 
   SimMCNP::TallyTYPE& tmap=Sim.getTallyMap();
 
@@ -976,8 +978,8 @@ mergeTally(SimMCNP& Sim,const int aNumber,
   return;
 }
 
-  
-  
+
+
 int
 setSDField(SimMCNP& Sim,const int tNumber,
           const std::string& fPart)
@@ -1010,7 +1012,7 @@ setSDField(SimMCNP& Sim,const int tNumber,
 
 int
 setParticleType(SimMCNP& Sim,const int tNumber,
-                const std::string& nPart) 
+                const std::string& nPart)
   /*!
     Get the last tally point based on the tallynumber
     Can use the mesh centre if no point tallies exist
@@ -1035,7 +1037,7 @@ setParticleType(SimMCNP& Sim,const int tNumber,
           fnum++;
 	}
 
-        
+
     }
   return fnum;
 }
@@ -1043,7 +1045,7 @@ setParticleType(SimMCNP& Sim,const int tNumber,
 int
 changeParticleType(SimMCNP& Sim,const int tNumber,
 		   const std::string& oPart,
-		   const std::string& nPart) 
+		   const std::string& nPart)
   /*!
     Get the last tally point based on the tallynumber
     Can use the mesh centre if no point tallies exist
@@ -1086,7 +1088,7 @@ addPointPD(SimMCNP& System)
   */
 {
   ELog::RegMethod RegA("TallyCreate","addPointPD");
-  
+
   const SimMCNP::TallyTYPE& tmap=System.getTallyMap();
   SimMCNP::TallyTYPE::const_iterator mc;
   for(mc=tmap.begin();mc!=tmap.end();mc++)
@@ -1096,17 +1098,17 @@ addPointPD(SimMCNP& System)
       if (PTptr)
 	{
 	  const masterRotate& MR=masterRotate::Instance();
-	  ModelSupport::pointDetOpt 
+	  ModelSupport::pointDetOpt
 	    PD(MR.reverseRotate(PTptr->getCentre()));
 	  PD.createObjAct(System);
 	  PD.addTallyOpt(System,PTptr->getKey());
 	}
     }
-  
+
   return;
 }
 
-int 
+int
 getLastTallyNumber(const SimMCNP& ASim,const int type)
   /*!
     Get the last tally nubmer
@@ -1120,12 +1122,12 @@ getLastTallyNumber(const SimMCNP& ASim,const int type)
   SimMCNP::TallyTYPE::const_iterator mc;
   for(mc=tmap.begin();mc!=tmap.end();mc++)
     {
-      if (mc->first>outN && 
+      if (mc->first>outN &&
 	  (!type || (mc->first % 10)==type))
 	outN=mc->first;
     }
   return outN;
 }
-  
+
 
 }  // NAMESPACE tallySystem

--- a/System/tally/fluxConstruct.cxx
+++ b/System/tally/fluxConstruct.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   tally/fluxConstruct.cxx
  *
  * Copyright (c) 2004-2021 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -59,8 +59,8 @@
 #include "SimMCNP.h"
 
 #include "inputParam.h"
-#include "objectSupport.h" 
-#include "fluxConstruct.h" 
+#include "objectSupport.h"
+#include "fluxConstruct.h"
 
 namespace tallySystem
 {
@@ -68,7 +68,7 @@ namespace tallySystem
 int
 fluxConstruct::processFlux(SimMCNP& System,
 			   const mainSystem::inputParam& IParam,
-			   const size_t Index) 
+			   const size_t Index)
   /*!
     Add flux tally (s) as needed
     \param System :: SimMCNP to add tallies
@@ -78,56 +78,44 @@ fluxConstruct::processFlux(SimMCNP& System,
 {
   ELog::RegMethod RegA("fluxConstruct","processFlux");
 
+  const std::string tallyName=
+    IParam.getValue<std::string>("tally",Index,0);
+
   const size_t NItems=IParam.itemCnt("tally",Index);
-  if (NItems<4)
-    throw ColErr::IndexError<size_t>(NItems,4,
+  if (NItems<5)
+    throw ColErr::IndexError<size_t>(NItems,5,
 				     "Insufficient items for tally");
-  // PARTICLE TYPE
-  const std::string PType(IParam.getValue<std::string>("tally",Index,1));
-  // Material TYPE
-  const std::string matType(IParam.getValue<std::string>("tally",Index,2));
-  // cellKey to extract
-  const std::string cellKey(IParam.getValue<std::string>("tally",Index,3));
+  const std::string PType(IParam.getValue<std::string>("tally",Index,2));
+  constexpr size_t cellIndex = 3;
+  const std::string cellKey(IParam.getValue<std::string>("tally",Index,cellIndex));
+  const std::string matType(IParam.getValue<std::string>("tally",Index,4));
 
   const std::set<int> cells=
     getNamedCellsWithMat(System,IParam,"tally",
-			Index,3,matType,
+			Index,cellIndex,matType,
 			"cellKey+"+matType+"cell/mat not present in model");
-  
-  
+
   const int nTally=System.nextTallyNum(4);
   tallySystem::addF4Tally(System,nTally,PType,cells);
-  tallySystem::Tally* TX=System.getTally(nTally); 
+  tallySystem::Tally* TX=System.getTally(nTally);
   TX->setPrintField("e f");
-  const std::string Comment=
-    "tally: "+std::to_string(nTally)+
-    " mat : "+matType+":"+
-    cellKey;
-  TX->setComment(Comment);
+  TX->setComment(tallyName);
   return 0;
 }
 
 
 void
-fluxConstruct::writeHelp(std::ostream& OX) 
+fluxConstruct::writeHelp(std::ostream& OX)
   /*!
     Write out help
     \param OX :: output stream
   */
 {
-  OX<<"Flux tally :\n"
-    "particles material(int) cells \n"
-    " -- material can be: \n"
-    "      zaid number \n"
-    "      material name \n"
-    "      material number \n"
-    "      -1 :: [all] \n"
-    "  -- cells can be \n"
-    "          objectName [cellOffset cellCount]\n"
-    "          objectName \n "
-    "          CellNumber-CellNumber\n";
+  OX<<"Flux tally options:\n"
+    "* particle objectName[:cellName] material\n"
+    "   set material to 'All' to tally all specified cells\n";
+
   return;
 }
-  
 
 }  // NAMESPACE tallySystem

--- a/System/tally/surfaceConstruct.cxx
+++ b/System/tally/surfaceConstruct.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   tally/surfaceConstruct.cxx
  *
  * Copyright (c) 2004-2019 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -56,12 +56,12 @@
 #include "inputParam.h"
 #include "TallyCreate.h"
 
-#include "surfaceConstruct.h" 
+#include "surfaceConstruct.h"
 
 namespace tallySystem
 {
 
-  
+
 void
 surfaceConstruct::processSurface(SimMCNP& System,
 				 const int idType,
@@ -77,26 +77,27 @@ surfaceConstruct::processSurface(SimMCNP& System,
   ELog::RegMethod RegA("surfaceConstruct","processSurface");
 
   const size_t NItems=IParam.itemCnt("tally",Index);
-  if (NItems<3)
-    throw ColErr::IndexError<size_t>(NItems,3,
+  if (NItems<4)
+    throw ColErr::IndexError<size_t>(NItems,4,
 				     "Insufficient items for tally");
-  const std::string pType(IParam.getValue<std::string>("tally",Index,1)); 
-  
 
+  const std::string tallyName=IParam.getValue<std::string>("tally",Index,0);
 
-  const std::string MType(IParam.getValue<std::string>("tally",Index,2)); 
+  const std::string pType(IParam.getValue<std::string>("tally",Index,3));
   ELog::EM<<"Surface Tally Type == "<<pType<<ELog::endDiag;
+
+  //  const std::string MType(IParam.getValue<std::string>("tally",Index,3));
   std::vector<std::string> excludeSurf;
   // Process a surface extracted from a linkPt of an object(FC)
   if (pType=="object")
     {
       const std::string place=
-	IParam.getValueError<std::string>("tally",Index,2,"position not given");
+	IParam.getValueError<std::string>("tally",Index,4,"position not given");
       const std::string linkName=
 	IParam.getValueError<std::string>
-	("tally",Index,3,"front/back/side not give");
-      
-      processSurfObject(System,idType,place,linkName,excludeSurf);
+	("tally",Index,5,"front/back/side not give");
+
+      processSurfObject(System,idType,place,linkName,excludeSurf,tallyName);
       return;
     }
 
@@ -104,36 +105,35 @@ surfaceConstruct::processSurface(SimMCNP& System,
   if (pType=="surfMap")
     {
       const std::string object=IParam.getValueError<std::string>
-	("tally",Index,2,"Object component not given");
-
+	("tally",Index,4,"Object component not given");
       const std::string surfItem=IParam.getValueError<std::string>
-	("tally",Index,3,"SurfMap set key not given");
+	("tally",Index,5,"SurfMap set key not given");
 
       // This should be a range (?):
       const long int surfIndex=IParam.getValueError<long int>
-	("tally",Index,4,"Index Offset direction");
-            
-      processSurfMap(System,idType,object,surfItem,surfIndex);
+	("tally",Index,6,"Index Offset direction");
+
+      processSurfMap(System,idType,object,surfItem,surfIndex,tallyName);
       return;
     }
 
   if (pType=="viewObject")
     {
       const std::string place=IParam.getValueError<std::string>
-	("tally",Index,2,"position not given");
+	("tally",Index,4,"position not given");
       const std::string linkName=IParam.getValueError<std::string>
-	("tally",Index,3,"front/back/side not give");
+	("tally",Index,5,"front/back/side not give");
 
-      std::vector<int> surfN;
       const size_t maxIndex=IParam.itemCnt("tally",Index);
-      for(size_t i=4;i<maxIndex;i++)
+      ELog::EM << "maxIndex: " << maxIndex << ELog::endDiag;
+      for(size_t i=6;i<maxIndex;i++)
 	{
 	  // Check for surface by S/R designator at end [to do]
 	  const std::string ST=
 	    IParam.getValue<std::string>("tally",Index,i);
 	  excludeSurf.push_back(ST);
 	}
-      processSurfObject(System,idType,place,linkName,excludeSurf);
+      processSurfObject(System,idType,place,linkName,excludeSurf,tallyName);
       return;
     }
   ELog::EM<<"Surface Tally NOT Processed"<<ELog::endErr;
@@ -146,18 +146,20 @@ surfaceConstruct::processSurfObject(SimMCNP& System,
 				    const int idType,
 				    const std::string& FObject,
 				    const std::string& linkName,
-				    const std::vector<std::string>& linkN)
+				    const std::vector<std::string>& linkN,
+				    const std::string& name)
   /*!
     Process a surface tally on a registered object
     \param System :: SimMCNP to add tallies
     \param FObject :: Fixed/Twin name
     \param linkName :: Link point [-ve for beam object]
     \param linkN :: surface exclude number for making a region of interest
+    \param name :: tally name (specified in input file as tally comment card)
     \return 1 on success / 0 on failure to find linkPt
   */
 {
   ELog::RegMethod RegA("surfaceConstruct","processSurfObject");
-  
+
   const int tNum=System.nextTallyNum(idType);
   const attachSystem::FixedComp* TPtr=
     System.getObjectThrow<attachSystem::FixedComp>(FObject,"FixedComp");
@@ -170,7 +172,7 @@ surfaceConstruct::processSurfObject(SimMCNP& System,
       for(size_t i=0;i<linkN.size();i++)
 	surfN.push_back(TPtr->getLinkSurf(linkN[i]));
 
-      addF1Tally(System,tNum,masterPlane,surfN);
+      addF1Tally(System,tNum,masterPlane,surfN,name);
       return 1;
     }
   return 0;
@@ -181,18 +183,20 @@ surfaceConstruct::processSurfMap(SimMCNP& System,
 				 const int idType,
 				 const std::string& SObject,
 				 const std::string& SurfUnit,
-				 const long int linkIndex) 
+				 const long int linkIndex,
+				 const std::string& name)
   /*!
     Process a surface tally on a registered object
     \param System :: SimMCNP to add tallies
     \param SObject :: SurfMap object for surfaces
     \param SurfUnit :: Object within surfMap
     \param linkIndex :: Index of surface [or -ve for all]
+    \param name :: tally name (specified in input file as tally comment card)
     \return 1 on success / 0 on failure to find linkPt
   */
 {
   ELog::RegMethod RegA("surfaceConstruct","processSurfMap");
-  
+
   const int tNum=System.nextTallyNum(idType);
   if (linkIndex)
     {
@@ -205,7 +209,7 @@ surfaceConstruct::processSurfMap(SimMCNP& System,
 
       const int surf=SPtr->getSurf(SurfUnit,index);
 
-      addF1Tally(System,tNum,side*surf);
+      addF1Tally(System,tNum,side*surf,name);
       return 1;
     }
   return 0;
@@ -214,13 +218,13 @@ surfaceConstruct::processSurfMap(SimMCNP& System,
 void
 surfaceConstruct::processSurfaceCurrent(SimMCNP& System,
                                         const mainSystem::inputParam& IParam,
-                                        const size_t Index) 
+                                        const size_t Index)
 /*!
     Add surface tally (s) as needed
     \param System :: SimMCNP to add tallies
     \param IParam :: Main input parameters
     \param Index :: index of the -T card
-    \return 1 on success / 0 on failure 
+    \return 1 on success / 0 on failure
   */
 {
   ELog::RegMethod RegA("surfaceConstruct","processSurfaceCurrent");
@@ -231,7 +235,7 @@ surfaceConstruct::processSurfaceCurrent(SimMCNP& System,
 void
 surfaceConstruct::processSurfaceFlux(SimMCNP& System,
                                      const mainSystem::inputParam& IParam,
-                                     const size_t Index) 
+                                     const size_t Index)
 /*!
     Add surface tally (s) as needed
     \param System :: SimMCNP to add tallies
@@ -239,27 +243,31 @@ surfaceConstruct::processSurfaceFlux(SimMCNP& System,
     \param Index :: index of the -T card
   */
 {
-  ELog::RegMethod RegA("surfaceConstruct","processSurfaceCurrent");
-  
+  ELog::RegMethod RegA("surfaceConstruct","processSurfaceFlux");
+
   processSurface(System,2,IParam,Index);
   return;
 }
 
 
-  
+
 void
-surfaceConstruct::writeHelp(std::ostream& OX) 
+surfaceConstruct::writeHelp(std::ostream& OX)
   /*!
     Write out help
     \param OX :: Output stream
   */
 {
   OX<<"Surface tally options:\n"
-    <<"object linkName\n"
-    <<"object objectName front/back \n"
-    <<"surfMap objectName surfName index-Direction \n"
-    <<"  -- indexDir is +/- 1-N surfaces stored under surfName\n"
-    <<"viewObject objectName front/back/N {1-4 designator} \n";
+    <<"* particle object  objectName linkName\n"
+    <<"* particle surfMap objectName surfaceName index-Direction \n"
+    <<"  (index-Direction is the surface index (starting from 1) stored under the same surfName,\n"
+    <<"   the surface index direction can be changed with the '-' sign which should not be screened or quoted)\n"
+    <<"* particle viewObject objectName linkName surfName1 surfName2 \\#surfName3 '#surfName4' ... \n"
+    <<"  (this option adds a corresponding tally segment card,\n"
+    <<"   the surface direction can be changed with the # symbol, which should be screened or quoted as shown above)\n";
+
+  OX << "\n Example: -T myname surface electron object MyObject back\n";
   return;
 }
 

--- a/System/tally/surfaceTally.cxx
+++ b/System/tally/surfaceTally.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   tally/surfaceTally.cxx
  *
  * Copyright (c) 2004-2018 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -87,7 +87,7 @@ surfaceTally::clone() const
 }
 
 surfaceTally&
-surfaceTally::operator=(const surfaceTally& A) 
+surfaceTally::operator=(const surfaceTally& A)
   /*!
     Assignment operator =
     \param A :: surfaceTally object to copy
@@ -134,7 +134,7 @@ surfaceTally::addLine(const std::string& LX)
   if (!StrFunc::section(Line,Tag))
     return -1;
 
-  // get tag+ number 
+  // get tag+ number
   std::pair<std::string,int> FUnit=Tally::getElm(Tag);
   if (FUnit.second<0)
     return -2;
@@ -155,7 +155,7 @@ surfaceTally::addLine(const std::string& LX)
 
   if (FUnit.first=="fs")             /// field seperator
     {
-      int SN;	  
+      int SN;
       FSfield.clear();
       while(StrFunc::section(Line,SN))
 	FSfield.push_back(SN);
@@ -169,7 +169,7 @@ surfaceTally::addLine(const std::string& LX)
 
   if (FUnit.first=="sf")             /// Segment divisor
     return SurfFlag.processString(Line);
-  
+
   return Tally::addLine(LX);
 }
 
@@ -212,7 +212,7 @@ surfaceTally::setSurfFlag(const std::vector<int>& SF)
 void
 surfaceTally::setSurfDivider(const std::vector<int>& TS)
   /*!
-    Set the surface division 
+    Set the surface division
     \param TS :: Surface numbers
    */
 {
@@ -245,7 +245,7 @@ surfaceTally::renumberSurf(const int oldN,const int newN)
   ELog::RegMethod RegA("surfaceTally","renumberCell");
 
   SurfFlag.changeItem(oldN,newN);
-  
+
   std::replace_if(SurfList.begin(),SurfList.end(),
 		  [&oldN](const int& x) { return (x==oldN); },
 		  newN);
@@ -261,21 +261,21 @@ surfaceTally::renumberSurf(const int oldN,const int newN)
 		  -newN);
   return;
 }
-  
+
 
 void
 surfaceTally::write(std::ostream& OX) const
   /*!
-    Writes out the surface tally depending on the 
+    Writes out the surface tally depending on the
     fields that have been set.
     \param OX :: Output Stream
   */
 {
   if (!isActive())
     return;
-  
+
   std::stringstream cx;
-  if (IDnum)  // maybe default 
+  if (IDnum)  // maybe default
     {
       cx<<"f"<<IDnum;
       if (!Particles.empty())

--- a/System/tallyInc/TallyCreate.h
+++ b/System/tallyInc/TallyCreate.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   tallyInc/TallyCreate.h
  *
  * Copyright (c) 2004-2021 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef tallySystem_TallyCreate_h
@@ -28,26 +28,26 @@ class SimMCNP;
 namespace tallySystem
 {
   class sswTally;
-  
+
   void setComment(SimMCNP&,const int,const std::string&);
   void cutTallyEnergy(SimMCNP&,const double);
   void setTallyTime(SimMCNP&,const int,const std::string&);
 
-  void addFullHeatBlock(SimMCNP&);             
-  void addHeatBlock(SimMCNP&,const std::vector<int>&);             
+  void addFullHeatBlock(SimMCNP&);
+  void addHeatBlock(SimMCNP&,const std::vector<int>&);
 
   int getLastTallyNumber(const SimMCNP&,const int);
 
   sswTally* addSSWTally(SimMCNP&);
-  
-  void addF1Tally(SimMCNP&,const int,const int);  //
+
+  void addF1Tally(SimMCNP&,const int,const int,const std::string&);
   void addF1Tally(SimMCNP&,const int,
-		  const int,const std::vector<int>&);  
+		  const int,const std::vector<int>&,const std::string&);
 
   void addF4Tally(SimMCNP&,const int,const std::string&,
-		  const std::set<int>&);    
+		  const std::set<int>&);
 
-  void addF7Tally(SimMCNP&,const int,const std::vector<int>&);    
+  void addF7Tally(SimMCNP&,const int,const std::vector<int>&);
 
   void addF5Tally(SimMCNP&,const int);
   void addF5Tally(SimMCNP&,const int,const Geometry::Vec3D&,
@@ -55,7 +55,7 @@ namespace tallySystem
   void setF5Position(SimMCNP&,const int,const Geometry::Vec3D&,
 		     const Geometry::Vec3D&,const double,const double);
   void setF5Position(SimMCNP&,const int,const Geometry::Vec3D&);
-  void setF5Angle(SimMCNP&,const int,const Geometry::Vec3D&,   
+  void setF5Angle(SimMCNP&,const int,const Geometry::Vec3D&,
 		  const double,const double);
   void modF5TallyCells(SimMCNP&,const int,const std::vector<int>&);
   void moveF5Tally(SimMCNP&,const int,const Geometry::Vec3D&);
@@ -81,7 +81,7 @@ namespace tallySystem
   int setSDField(SimMCNP&,const int,const std::string&);
   int setSingle(SimMCNP&,const int);
   int setFormat(SimMCNP&,const int,const std::string&);
-  
+
   void mergeTally(SimMCNP&,const int,const int);
   void deleteTallyType(SimMCNP&,const int);
   void deleteTally(SimMCNP&,const int);
@@ -93,6 +93,6 @@ namespace tallySystem
   // WRONG PLACE
   void addXMLtally(Simulation&,const std::string&);
 
-}  // namespace tallySystem 
+}  // namespace tallySystem
 
 #endif

--- a/System/tallyInc/surfaceConstruct.h
+++ b/System/tallyInc/surfaceConstruct.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   tallyInc/surfaceConstruct.h
  *
  * Copyright (c) 2004-2018 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef tallySystem_surfaceConstruct_h
@@ -35,7 +35,7 @@ namespace tallySystem
 {
 
 /*!
-  \class surfaceConstruct 
+  \class surfaceConstruct
   \version 1.0
   \author S. Ansell
   \date April 2012
@@ -44,36 +44,36 @@ namespace tallySystem
   Provides linkage to its outside on FixedComp[0]
 */
 
-class surfaceConstruct 
+class surfaceConstruct
 {
  private:
 
   static int processSurfObject(SimMCNP&,const int,
 			       const std::string&,
 			       const std::string&,
-			       const std::vector<std::string>&);
-  
+			       const std::vector<std::string>&,const std::string&);
+
   static int processSurfMap(SimMCNP&,const int,
 			    const std::string&,
 			    const std::string&,
-			    const long int);
+			    const long int,const std::string&);
 
   static void processSurface(SimMCNP&,const int,
 			    const mainSystem::inputParam&,
 			    const size_t);
 
-  /// private constructor 
+  /// private constructor
   surfaceConstruct();
-  
+
  public:
 
 
 
 
   static void processSurfaceCurrent(SimMCNP&,const mainSystem::inputParam&,
-			       const size_t);
+				    const size_t);
   static void processSurfaceFlux(SimMCNP&,const mainSystem::inputParam&,
-			    const size_t);
+				 const size_t);
 
   static void writeHelp(std::ostream&);
 };
@@ -81,4 +81,3 @@ class surfaceConstruct
 }
 
 #endif
- 

--- a/all.sh
+++ b/all.sh
@@ -9,27 +9,31 @@ inp="/tmp/AA"
 
 # FLUKA estimators
 # the uq is a perl replacement string to unquote the argument
-$parallel ./maxiv -fluka infn -defaultConfig Linac -T '{=1 uq(); =}' ::: \
- "myname resnuclei InjectionHall:Floor Concrete $inp" \
- "myname resnuclei InjectionHall:Floor $inp" \
- "myname surface electron InjectionHall back $inp" \
- "myname surface 'e+&e-'  InjectionHall back 1e-11 3000 100 0 6.28318 3 $inp" \
- "help $inp" "help resnuclei $inp" "help surface $inp"  || exit
+$parallel ./maxiv -fluka infn -defaultConfig Linac -T '{=1 uq(); =}' $inp ::: \
+ "myname resnuclei InjectionHall:Floor Concrete" \
+ "myname resnuclei InjectionHall:Floor" \
+ "myname surface electron InjectionHall back" \
+ "myname surface 'e+&e-'  InjectionHall back 1e-11 3000 100 0 6.28318 3" \
+ "myname surface electron InjectionHall back  -TMod energy myname 1e-11 3000 100" \
+ "myname mesh dose-eq free 'Vec3D(-15.0,-400.0,-55.0)' 'Vec3D(15.0, 40.0,40.0)' 10 20 30 " \
+ "myname mesh dose-eq free 'Vec3D(-15.0,-400.0,-55.0)' 'Vec3D(15.0, 40.0,40.0)' 10 20 30 -TMod doseType myname  all-part EWT74" \
+ "-TMod help " \
+ "help" "help resnuclei" "help surface"  || exit
 
 # MCNP tallies
-$parallel ./maxiv -defaultConfig Linac -T myname '{=1 uq(); =}' ::: \
-	 " surface e object     InjectionHall back $inp" \
-	 " surface e surfMap    InjectionHall InnerBack  1 $inp" \
-	 " surface e surfMap    InjectionHall InnerBack -1 $inp" \
-	 " surface e viewObject InjectionHall front BackWallFront \#BackWallBack '#SPFMazeIn' $inp" \
-	 " flux e InjectionHall:Floor Concrete $inp" \
-	 " flux e InjectionHall:Floor All $inp" || exit
+$parallel ./maxiv -defaultConfig Linac -T myname '{=1 uq(); =}' $inp ::: \
+	 " surface e object     InjectionHall back" \
+	 " surface e surfMap    InjectionHall InnerBack  1" \
+	 " surface e surfMap    InjectionHall InnerBack -1" \
+	 " surface e viewObject InjectionHall front BackWallFront \#BackWallBack '#SPFMazeIn'" \
+	 " flux e InjectionHall:Floor Concrete" \
+	 " flux e InjectionHall:Floor All" || exit
 
 # GEOMETRY
-$parallel ::: "./maxiv --noLengthCheck --defaultConfig Linac All $opts $inp" \
-	  "./ess --bunkerPillars ABunker $opts $inp" \
-	  "./ess --topModType Butterfly $opts $inp" \
-	  "./ess --topModType Pancake   $opts $inp" || exit
+$parallel {} $inp ::: "./maxiv --noLengthCheck --defaultConfig Linac All $opts" \
+	  "./ess --bunkerPillars ABunker $opts" \
+	  "./ess --topModType Butterfly $opts" \
+	  "./ess --topModType Pancake   $opts" || exit
 
 $parallel "./maxiv --defaultConfig Single {} $opts $inp " ::: \
    SOFTIMAX BALDER COSAXS DANMAX FORMAX MICROMAX SPECIES MAXPEEM || exit

--- a/all.sh
+++ b/all.sh
@@ -4,41 +4,43 @@ exec >/dev/null
 
 nValid=1000
 opts="--validAll --validCheck $nValid"
-# parallel options
 parallel="parallel -u --bar --halt now,fail=1"
+inp="/tmp/AA"
 
 # FLUKA estimators
 # the uq is a perl replacement string to unquote the argument
-$parallel ./maxiv -fluka infn -defaultConfig Linac '{=1 uq(); =}' ::: \
- " -T floor resnuc InjectionHall:Floor Concrete AA" \
- " -T floor resnuc InjectionHall:Floor AA" \
- " -T spect surface electron InjectionHall back AA" || exit
+$parallel ./maxiv -fluka infn -defaultConfig Linac -T '{=1 uq(); =}' ::: \
+ " myname resnuclei InjectionHall:Floor Concrete $inp" \
+ " myname resnuclei InjectionHall:Floor $inp" \
+ " myname surface electron InjectionHall back $inp" \
+ " myname surface 'e+&e-'  InjectionHall back 1e-11 3000 100 0 6.28318 3 $inp" \
+ "help resnuclei $inp" "help surface $inp"  || exit
+# " help $inp"  || exit
 
 # MCNP tallies
-$parallel ./maxiv -defaultConfig Linac '{=1 uq(); =}' ::: \
-	 " -T spect surface electron object     InjectionHall back AA" \
-	 " -T spect surface electron surfMap    InjectionHall InnerBack  1 AA" \
-	 " -T spect surface electron surfMap    InjectionHall InnerBack -1 AA" \
-	 " -T spect surface electron viewObject InjectionHall front BackWallFront \#BackWallBack '#SPFMazeIn' AA"  || exit
+$parallel ./maxiv -defaultConfig Linac -T myname '{=1 uq(); =}' ::: \
+	 " surface electron object     InjectionHall back $inp" \
+	 " surface electron surfMap    InjectionHall InnerBack  1 $inp" \
+	 " surface electron surfMap    InjectionHall InnerBack -1 $inp" \
+	 " surface electron viewObject InjectionHall front BackWallFront \#BackWallBack '#SPFMazeIn' $inp"  || exit
 
 # GEOMETRY
-$parallel ::: \
-	 "./maxiv --noLengthCheck --defaultConfig Linac All $opts AA" \
-	 "./ess --bunkerPillars ABunker $opts AA" \
-	 "./ess --topModType Butterfly $opts AA" \
-	 "./ess --topModType Pancake   $opts AA" || exit
+$parallel ::: "./maxiv --noLengthCheck --defaultConfig Linac All $opts $inp" \
+	  "./ess --bunkerPillars ABunker $opts $inp" \
+	  "./ess --topModType Butterfly $opts $inp" \
+	  "./ess --topModType Pancake   $opts $inp" || exit
 
-$parallel "./maxiv --defaultConfig Single {} $opts AA " ::: \
+$parallel "./maxiv --defaultConfig Single {} $opts $inp " ::: \
    SOFTIMAX BALDER COSAXS DANMAX FORMAX MICROMAX SPECIES MAXPEEM || exit
 
-$parallel "./{} $opts AA" ::: t1Real reactor saxsSim || exit
+$parallel "./{} $opts $inp" ::: t1Real reactor saxsSim || exit
 
-parallel --bar $popts "./ess --defaultConfig Single {} $opts AA" ::: \
+$parallel "./ess --defaultConfig Single {} $opts $inp" ::: \
  VESPA ESTIA CSPEC  ODIN MAGIC BIFROST LOKI NMX  NNBAR  DREAM  BEER   \
  FREIA SKADI MIRACLES TESTBEAM TREX VOR    || exit
 # HEIMDAL :: Not currently correct -- update underway
 
-$parallel "./singleItem --singleItem {} $opts AA" ::: \
+$parallel "./singleItem --singleItem {} $opts $inp" ::: \
  BeamDivider BeamScrapper Bellow BlankTube BoxJaws         \
  BremBlock BremTube  ButtonBPM CRLTube  CeramicGap CleaningMagnet  \
  CollTube ConnectorTube CooledScreen CooledUnit CornerPipe \
@@ -57,5 +59,5 @@ $parallel "./singleItem --singleItem {} $opts AA" ::: \
 exit
 
 ## Need to fix the cooling pads on the reflector
-./fullBuild $opts AA || exit
+./fullBuild $opts $inp || exit
 exit

--- a/all.sh
+++ b/all.sh
@@ -17,7 +17,6 @@ $parallel ./maxiv -fluka infn -defaultConfig Linac -T '{=1 uq(); =}' $inp ::: \
  "myname surface electron InjectionHall back  -TMod energy myname 1e-11 3000 100" \
  "myname mesh dose-eq free 'Vec3D(-15.0,-400.0,-55.0)' 'Vec3D(15.0, 40.0,40.0)' 10 20 30 " \
  "myname mesh dose-eq free 'Vec3D(-15.0,-400.0,-55.0)' 'Vec3D(15.0, 40.0,40.0)' 10 20 30 -TMod doseType myname  all-part EWT74" \
- "-TMod help " \
  "help" "help resnuclei" "help surface"  || exit
 
 # MCNP tallies

--- a/all.sh
+++ b/all.sh
@@ -5,25 +5,40 @@ exec >/dev/null
 nValid=1000
 opts="--validAll --validCheck $nValid"
 # parallel options
-popts="-u --bar --halt now,fail=1"
+parallel="parallel -u --bar --halt now,fail=1"
 
-parallel $popts ::: \
+# FLUKA estimators
+# the uq is a perl replacement string to unquote the argument
+$parallel ./maxiv -fluka infn -defaultConfig Linac '{=1 uq(); =}' ::: \
+ " -T floor resnuc InjectionHall:Floor Concrete AA" \
+ " -T floor resnuc InjectionHall:Floor AA" \
+ " -T spect surface electron InjectionHall back AA" || exit
+
+# MCNP tallies
+$parallel ./maxiv -defaultConfig Linac '{=1 uq(); =}' ::: \
+	 " -T spect surface electron object     InjectionHall back AA" \
+	 " -T spect surface electron surfMap    InjectionHall InnerBack  1 AA" \
+	 " -T spect surface electron surfMap    InjectionHall InnerBack -1 AA" \
+	 " -T spect surface electron viewObject InjectionHall front BackWallFront \#BackWallBack '#SPFMazeIn' AA"  || exit
+
+# GEOMETRY
+$parallel ::: \
 	 "./maxiv --noLengthCheck --defaultConfig Linac All $opts AA" \
 	 "./ess --bunkerPillars ABunker $opts AA" \
 	 "./ess --topModType Butterfly $opts AA" \
 	 "./ess --topModType Pancake   $opts AA" || exit
 
-parallel $popts "./maxiv --defaultConfig Single {} $opts AA " ::: \
+$parallel "./maxiv --defaultConfig Single {} $opts AA " ::: \
    SOFTIMAX BALDER COSAXS DANMAX FORMAX MICROMAX SPECIES MAXPEEM || exit
 
-parallel $popts "./{} $opts AA" ::: t1Real reactor saxsSim || exit
+$parallel "./{} $opts AA" ::: t1Real reactor saxsSim || exit
 
 parallel --bar $popts "./ess --defaultConfig Single {} $opts AA" ::: \
  VESPA ESTIA CSPEC  ODIN MAGIC BIFROST LOKI NMX  NNBAR  DREAM  BEER   \
  FREIA SKADI MIRACLES TESTBEAM TREX VOR    || exit
 # HEIMDAL :: Not currently correct -- update underway
 
-parallel $popts "./singleItem --singleItem {} $opts AA" ::: \
+$parallel "./singleItem --singleItem {} $opts AA" ::: \
  BeamDivider BeamScrapper Bellow BlankTube BoxJaws         \
  BremBlock BremTube  ButtonBPM CRLTube  CeramicGap CleaningMagnet  \
  CollTube ConnectorTube CooledScreen CooledUnit CornerPipe \

--- a/all.sh
+++ b/all.sh
@@ -10,12 +10,11 @@ inp="/tmp/AA"
 # FLUKA estimators
 # the uq is a perl replacement string to unquote the argument
 $parallel ./maxiv -fluka infn -defaultConfig Linac -T '{=1 uq(); =}' ::: \
- " myname resnuclei InjectionHall:Floor Concrete $inp" \
- " myname resnuclei InjectionHall:Floor $inp" \
- " myname surface electron InjectionHall back $inp" \
- " myname surface 'e+&e-'  InjectionHall back 1e-11 3000 100 0 6.28318 3 $inp" \
- "help resnuclei $inp" "help surface $inp"  || exit
-# " help $inp"  || exit
+ "myname resnuclei InjectionHall:Floor Concrete $inp" \
+ "myname resnuclei InjectionHall:Floor $inp" \
+ "myname surface electron InjectionHall back $inp" \
+ "myname surface 'e+&e-'  InjectionHall back 1e-11 3000 100 0 6.28318 3 $inp" \
+ "help $inp" "help resnuclei $inp" "help surface $inp"  || exit
 
 # MCNP tallies
 $parallel ./maxiv -defaultConfig Linac -T myname '{=1 uq(); =}' ::: \

--- a/all.sh
+++ b/all.sh
@@ -18,10 +18,12 @@ $parallel ./maxiv -fluka infn -defaultConfig Linac -T '{=1 uq(); =}' ::: \
 
 # MCNP tallies
 $parallel ./maxiv -defaultConfig Linac -T myname '{=1 uq(); =}' ::: \
-	 " surface electron object     InjectionHall back $inp" \
-	 " surface electron surfMap    InjectionHall InnerBack  1 $inp" \
-	 " surface electron surfMap    InjectionHall InnerBack -1 $inp" \
-	 " surface electron viewObject InjectionHall front BackWallFront \#BackWallBack '#SPFMazeIn' $inp"  || exit
+	 " surface e object     InjectionHall back $inp" \
+	 " surface e surfMap    InjectionHall InnerBack  1 $inp" \
+	 " surface e surfMap    InjectionHall InnerBack -1 $inp" \
+	 " surface e viewObject InjectionHall front BackWallFront \#BackWallBack '#SPFMazeIn' $inp" \
+	 " flux e InjectionHall:Floor Concrete $inp" \
+	 " flux e InjectionHall:Floor All $inp" || exit
 
 # GEOMETRY
 $parallel ::: "./maxiv --noLengthCheck --defaultConfig Linac All $opts $inp" \

--- a/all.sh
+++ b/all.sh
@@ -1,44 +1,29 @@
+#!/usr/bin/env bash
 
-
+exec >/dev/null
 
 nValid=1000
+opts="--validAll --validCheck $nValid"
+# parallel options
+popts="-u --bar --halt now,fail=1"
 
-#./maxiv --defaultConfig Single SOFTIMAX AA 
-#./maxiv --defaultConfig Single SOFTIMAX --validRandom 190  --validCheck $nValid AA || exit
-# exit
-#segments=$(for i in {40..49}; do echo -n "Segment$i "; done)
-segments=All
-./singleItem --singleItem UTubePipe --validAll --validCheck $nValid AA 
-#exit
+parallel $popts ::: \
+	 "./maxiv --noLengthCheck --defaultConfig Linac All $opts AA" \
+	 "./ess --bunkerPillars ABunker $opts AA" \
+	 "./ess --topModType Butterfly $opts AA" \
+	 "./ess --topModType Pancake   $opts AA" || exit
 
-
-# ./ess --defaultConfig Single VESPA --validAll --validCheck $nValid AA  || exit
-# ./ess --defaultConfig Single HEIMDAL --validAll --validCheck $nValid AA  || exit
-
-## SOFTIMAX removed because making the new M1 mirror
-parallel --halt now,fail=1 "./maxiv --defaultConfig Single {} --validAll --validCheck $nValid AA" ::: \
+parallel $popts "./maxiv --defaultConfig Single {} $opts AA " ::: \
    SOFTIMAX BALDER COSAXS DANMAX FORMAX MICROMAX SPECIES MAXPEEM || exit
 
-## SOFTIMAX 
+parallel $popts "./{} $opts AA" ::: t1Real reactor saxsSim || exit
 
-
-./maxiv --noLengthCheck --defaultConfig Linac ${segments} --validAll --validCheck $nValid AA || exit 
-
-
-./t1Real -validAll --validCheck ${nValid} AA || exit
-./reactor -validAll --validCheck ${nValid} AA || exit
-## ./saxs -validAll --validCheck ${nValid} AA || exit
-
-parallel --halt now,fail=1 "./ess --topModType {} --validAll --validCheck $nValid AA" ::: \
-     Butterfly Pancake 
-./ess --bunkerPillars ABunker --validAll --validCheck $nValid AA  || exit
-
-parallel --halt now,fail=1 "./ess --defaultConfig Single {} --validAll --validCheck $nValid AA" ::: \
- ESTIA CSPEC  ODIN MAGIC BIFROST LOKI NMX  NNBAR  DREAM  BEER   \
- FREIA SKADI MIRACLES TESTBEAM TREX VESPA VOR    || exit
+parallel --bar $popts "./ess --defaultConfig Single {} $opts AA" ::: \
+ VESPA ESTIA CSPEC  ODIN MAGIC BIFROST LOKI NMX  NNBAR  DREAM  BEER   \
+ FREIA SKADI MIRACLES TESTBEAM TREX VOR    || exit
 # HEIMDAL :: Not currently correct -- update underway
 
-parallel --halt now,fail=1 "./singleItem --singleItem {} --validAll --validCheck $nValid AA" ::: \
+parallel $popts "./singleItem --singleItem {} $opts AA" ::: \
  BeamDivider BeamScrapper Bellow BlankTube BoxJaws         \
  BremBlock BremTube  ButtonBPM CRLTube  CeramicGap CleaningMagnet  \
  CollTube ConnectorTube CooledScreen CooledUnit CornerPipe \
@@ -52,10 +37,10 @@ parallel --halt now,fail=1 "./singleItem --singleItem {} --validAll --validCheck
  PortTube PrismaChamber Quadrupole  \
  R3ChokeChamber RoundMonoShutter Scrapper Sexupole SixPort StriplineBPM \
  TWCavity TargetShield TriGroup TriPipe TriggerTube UndVac UndulatorVacuum \
- UTubePipe VacuumPipe ViewTube YAG YagScreen YagUnit default uVac  || exit
+ UTubePipe VacuumPipe ViewTube YAG YagScreen YagUnit default uVac || exit
 
 exit
 
 ## Need to fix the cooling pads on the reflector
-./fullBuild -validAll --validCheck ${nValid} AA || exit
+./fullBuild $opts AA || exit
 exit

--- a/src/SimFLUKA.cxx
+++ b/src/SimFLUKA.cxx
@@ -3,7 +3,7 @@
 
  * File:   src/SimFLUKA.cxx
  *
- * Copyright (c) 2004-2023 by Stuart Ansell / Konstantin Batkov
+ * Copyright (c) 2004-2024 by Stuart Ansell / Konstantin Batkov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -304,7 +304,7 @@ SimFLUKA::addUserFlags(const std::string& Key,const std::string& Extra)
 void
 SimFLUKA::writeTally(std::ostream& OX) const
   /*!
-    Writes out the tallies 
+    Writes out the tallies
     \param OX :: Output stream
    */
 {
@@ -403,7 +403,7 @@ SimFLUKA::writeMagField(std::ostream& OX) const
       for(const OTYPE::value_type& mp : OList)
 	{
 	  const int magType=mp.second->hasMagField(); // 1:normal 2:sync
-	  if (magType)  
+	  if (magType)
 	    {
 	      const std::pair<double,double> magStep=
 		mp.second->getMagStep();
@@ -559,20 +559,20 @@ SimFLUKA::writeElements(std::ostream& OX) const
     {
       if (!za.getZaid().empty())
 	{
-	  cx<<"MATERIAL "<<za.getZ()<<". - "<<" 1."
-	    <<" - - "<<za.getIso()<<". "<<za.getFlukaName()<<" ";
+	  cx<<"MATERIAL "<<za.getZ()<<" - "<<" 1 "
+	    <<" - - "<<za.getIso()<<" "<<za.getFlukaName()<<" ";
 	  lowmat<<lowMatFunc(za.getZ(),za.getIso(),za.getFlukaName());
 	}
     }
 
-  
 
-	  
-  
+
+
+
   StrFunc::writeFLUKA(cx.str(),OX);
   if (lowEnergyNeutron)
     StrFunc::writeFLUKA(lowmat.str(),OX);
-  
+
   OX<<alignment<<std::endl;
 
   return;
@@ -686,7 +686,7 @@ SimFLUKA::writePhysics(std::ostream& OX) const
   cx<<"START "<<static_cast<double>(nps);
   StrFunc::writeFLUKA(cx.str(),OX);
   cx.str("");
-  cx<<"RANDOMIZE 1.0 "<<std::to_string(rndSeed % 1000000);
+  cx<<"RANDOMIZE 1 "<<std::to_string(rndSeed % 1000000);
   StrFunc::writeFLUKA(cx.str(),OX);
   // Remaining Physics cards
   PhysPtr->writeFLUKA(OX);
@@ -784,7 +784,7 @@ SimFLUKA::write(const std::string& Fname) const
     }
 
   // cell/names(not numbers)/free geometry
-  StrFunc::writeFLUKA("GLOBAL "+std::to_string(nCells)+" - 1.0 1.0",OX);
+  StrFunc::writeFLUKA("GLOBAL "+std::to_string(nCells)+" - 1 1",OX);
   OX<<"TITLE"<<std::endl;
   OX<<" Fluka model from CombLayer http://github.com/SAnsell/CombLayer"
     <<std::endl;
@@ -803,7 +803,7 @@ SimFLUKA::write(const std::string& Fname) const
   StrFunc::writeFLUKA("DEFAULTS - - - - - - PRECISION",OX);
   std::ostringstream cx;
   cx<<"GEOBEGIN";
-  cx<<((basicGeom) ? " - " : " 1.0 ");
+  cx<<((basicGeom) ? " - " : " 1 ");
   cx<<geomPrecision<<" - - - - COMBNAME";
   StrFunc::writeFLUKA(cx.str(),OX);
 


### PR DESCRIPTION
This PR intruduces support for tally names.
The syntax for all available tallies can be found in the first two sections of the [all.sh](https://github.com/SAnsell/CombLayer/blob/866a055de43701ac7bb5c8517be353afa77d196d/all.sh#L12) script. In short, you now need to specify the tally name right after the `-T` argument.
An advantage of naming the tallies is that, once converted into ROOT files using [mc-tools](https://github.com/kbat/mc-tools), the corresponding histograms will have recognisable names instead of auto-generated numbered names.

I have checked with the `all.sh` script that this PR does not introduce any changes in the geometry of existing models.

Note:
Currently, all FLUKA estimators and most MCNP tallies are supported, but none of the PHITS tallies. The code will crash if unsupported tallies are specified. Therefore, it’s probably best to postpone merging into the master branch until full tally support is implemented. However, I’m submitting this PR now to announce the upcoming changes and hopefully encourage others to contribute to improving it.