### PR TITLE
replace --basicGeom with --complexGeom to invert GEOBEGIN behaviour

### DIFF
--- a/System/flukaProcess/flukaDefPhysics.cxx
+++ b/System/flukaProcess/flukaDefPhysics.cxx
@@ -74,8 +74,8 @@ setDefaultPhysics(SimFLUKA& System,
   // trick to allow 1e8 entries etc.
   System.setNPS(static_cast<size_t>(IParam.getValue<double>("nps")));
   System.setRND(IParam.getValue<long int>("random"));
-  if (IParam.flag("basicGeom"))
-    System.setBasicGeom();
+  if (IParam.flag("complexGeom"))
+    System.setComplexGeom();
   if (IParam.flag("geomPrecision"))
     System.setGeomPrecision(IParam.getValue<double>("geomPrecision"));
   return;

--- a/System/generalProcess/MainInputs.cxx
+++ b/System/generalProcess/MainInputs.cxx
@@ -75,7 +75,7 @@ createInputs(inputParam& IParam)
 
   IParam.regFlag("a","axis");
   IParam.regMulti("angle","angle",10000,1,8);
-  IParam.regFlag("basicGeom","basicGeom");
+  IParam.regFlag("complexGeom","complexGeom");
   IParam.regDefItem<int>("c","cellRange",2,0,0);
   IParam.regItem("C","ECut");
   IParam.regDefItem<double>("cutWeight","cutWeight",2,0.5,0.25);
@@ -250,7 +250,7 @@ createInputs(inputParam& IParam)
     
   IParam.setDesc("angle","Orientate to component [name]");
   IParam.setDesc("axis","Rotate to main axis rotation [TS2]");
-  IParam.setDesc("basicGeom","Use basic fluka geometry system");
+  IParam.setDesc("complexGeom","Use complex fluka geometry system (DNF+CSG)");
   IParam.setDesc("geomPrecision","Set geometry accuracy  : 1e-6cm * value");
   IParam.setDesc("c","Cells to protect");
   IParam.setDesc("cutWeight","Set the cut weights (wc1/wc2)" );

--- a/include/SimFLUKA.h
+++ b/include/SimFLUKA.h
@@ -63,7 +63,7 @@ class SimFLUKA : public Simulation
   const std::string alignment;    ///< the alignemnt string
 
   std::string defType;            ///< Default physics type
-  bool basicGeom;                 ///< Use basic geometry [DNF form only]
+  bool complexGeom;               ///< Use complex geometry [DNF+CSG form]
   double geomPrecision;           ///< Precision (*1e-6) to use [def 0.0001]
   bool writeVariable;             ///< Prevent the writing of variables
   bool lowEnergyNeutron;          ///< Low energy neutron assigned
@@ -141,8 +141,8 @@ class SimFLUKA : public Simulation
   /// set rndseed [move to physics]
   void setRND(const long int N) { rndSeed=N; }
 
-  /// set the basic geometry
-  void setBasicGeom() { basicGeom=1; }
+  /// set the complex geometry
+  void setComplexGeom() { complexGeom=1; }
   /// set the geomtry precision
   void setGeomPrecision(const double D) { geomPrecision=D; }
 

--- a/src/SimFLUKA.cxx
+++ b/src/SimFLUKA.cxx
@@ -86,7 +86,7 @@
 SimFLUKA::SimFLUKA() :
   Simulation(),
   alignment("*...+.WHAT....+....1....+....2....+....3....+....4....+....5....+....6....+.SDUM"),
-  defType("PRECISION"),basicGeom(0),geomPrecision(0.0001),
+  defType("PRECISION"),complexGeom(0),geomPrecision(0.0001),
   writeVariable(1),lowEnergyNeutron(1),cernFluka(0),
   nps(1000),rndSeed(2374891),
   PhysPtr(new flukaSystem::flukaPhysics()),
@@ -100,7 +100,7 @@ SimFLUKA::SimFLUKA() :
 SimFLUKA::SimFLUKA(const SimFLUKA& A) :
   Simulation(A),
   alignment(A.alignment),defType(A.defType),
-  basicGeom(A.basicGeom),geomPrecision(A.geomPrecision),
+  complexGeom(A.complexGeom),geomPrecision(A.geomPrecision),
   writeVariable(A.writeVariable),
   lowEnergyNeutron(A.lowEnergyNeutron),
   nps(A.nps),rndSeed(A.rndSeed),
@@ -126,7 +126,7 @@ SimFLUKA::operator=(const SimFLUKA& A)
     {
       Simulation::operator=(A);
       defType=A.defType;
-      basicGeom=A.basicGeom;
+      complexGeom=A.complexGeom;
       writeVariable=A.writeVariable;
       lowEnergyNeutron=A.lowEnergyNeutron;
       nps=A.nps;
@@ -803,7 +803,7 @@ SimFLUKA::write(const std::string& Fname) const
   StrFunc::writeFLUKA("DEFAULTS - - - - - - PRECISION",OX);
   std::ostringstream cx;
   cx<<"GEOBEGIN";
-  cx<<((basicGeom) ? " - " : " 1 ");
+  cx<<((complexGeom) ? " 1 " : " - ");
   cx<<geomPrecision<<" - - - - COMBNAME";
   StrFunc::writeFLUKA(cx.str(),OX);
 


### PR DESCRIPTION
The old --basicGeom flag disables online parenthesis expansion in FLUKA. The new --complexGeom flag does the opposite: when the flag is absent, online parenthesis expansion is disabled, and when it is present, it is enabled (complex/DNF+CSG geometry)

This change was introduced due to a FLUKA bug affecting complexGeom, which can produce false-positive lost particles. For this reason, basicGeom geometry is now generated by default.

The commit should be reverted after the bug is fixed in FLUKA because online expansion is more user-friendly.