### PR TITLE
USRBIN follows geometry translation

### DIFF
--- a/System/attachComp/FixedComp.cxx
+++ b/System/attachComp/FixedComp.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   attachComp/FixedComp.cxx
  *
  * Copyright (c) 2004-2025 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <algorithm>
@@ -55,14 +55,14 @@
 
 namespace attachSystem
 {
-  
+
 FixedComp::FixedComp(const size_t NL,std::string  KN) :
   keyName(std::move(KN)),buildIndex(0),
   cellIndex(buildIndex+1),keyMap({{"front",0},{"back",1}}),
   X(Geometry::Vec3D(1,0,0)),Y(Geometry::Vec3D(0,1,0)),
   Z(Geometry::Vec3D(0,0,1)),primeAxis(0),LU(NL)
  /*!
-    Non-registered Constructor 
+    Non-registered Constructor
     \param NL :: Number of links
   */
 {}
@@ -70,7 +70,7 @@ FixedComp::FixedComp(const size_t NL,std::string  KN) :
 FixedComp::FixedComp(const size_t NL) :
   FixedComp(NL,"Null")
  /*!
-    Non-registered Constructor 
+    Non-registered Constructor
     \param NL :: Number of links
   */
 {}
@@ -83,7 +83,7 @@ FixedComp::FixedComp(const std::string& KN,const size_t NL,
   X(Geometry::Vec3D(1,0,0)),Y(Geometry::Vec3D(0,1,0)),
   Z(Geometry::Vec3D(0,0,1)),primeAxis(0),LU(NL)
  /*!
-    Constructor 
+    Constructor
     \param KN :: KeyName
     \param NL :: Number of links
     \param resSize :: Reserved size for indexes [default: 10000]
@@ -98,7 +98,7 @@ FixedComp::FixedComp(const std::string& KN,const size_t NL,
   X(Geometry::Vec3D(1,0,0)),Y(Geometry::Vec3D(0,1,0)),
   Z(Geometry::Vec3D(0,0,1)),Origin(std::move(O)),primeAxis(0),LU(NL)
   /*!
-    Constructor 
+    Constructor
     \param KN :: KeyName
     \param NL :: Number of links
     \param O :: Origin Point
@@ -126,7 +126,7 @@ FixedComp::FixedComp(const std::string& KN,const size_t NL,
   */
 {}
 
-FixedComp::FixedComp(const FixedComp& A) : 
+FixedComp::FixedComp(const FixedComp& A) :
   keyName(A.keyName),SMap(A.SMap),
   buildIndex(A.buildIndex),
   cellIndex(A.cellIndex),
@@ -172,21 +172,21 @@ FixedComp::setAxisControl(const long int axisIndex,
   /*!
     Set the new reorientation axis
     \param axisIndex :: X/Y/Z for reorientation [1-3]
-    \param NAxis :: New Axis 
+    \param NAxis :: New Axis
   */
 {
   ELog::RegMethod RegA("FixedComp","setAxisControl");
-  
+
   if (NAxis.abs()<Geometry::zeroTol)
     throw ColErr::NumericalAbort("NAxis is zero");
   if (axisIndex>3 || axisIndex<-3)
     throw ColErr::IndexError<long int>(axisIndex,2,"axisIndex");
-    
+
   orientateAxis=NAxis.unit(); ///< Axis for reorientation
   primeAxis=axisIndex;
   return;
 }
-  
+
 
 void
 FixedComp::createUnitVector(const FixedComp& FC)
@@ -225,7 +225,7 @@ FixedComp::createUnitVector(const FixedComp& FC,
   Origin=POrigin;
 
   if (primeAxis>0) reOrientate();
-  
+
   return;
 }
 
@@ -243,7 +243,7 @@ FixedComp::createUnitVector(const FixedComp& FC,
   return;
 }
 
-  
+
 void
 FixedComp::createUnitVector(const FixedComp& FC,
 			    const long int orgIndex,
@@ -308,7 +308,7 @@ FixedComp::createUnitVector(const FixedComp& orgFC,
   return;
 }
 
-  
+
 void
 FixedComp::createUnitVector(const Geometry::Vec3D& OG,
 			    const Geometry::Vec3D& Axis)
@@ -322,7 +322,7 @@ FixedComp::createUnitVector(const Geometry::Vec3D& OG,
 
   Y=Axis.unit();
   X=Y.crossNormal();
-  Z=X*Y;  
+  Z=X*Y;
   makeOrthogonal();
   Origin=OG;
   if (primeAxis>0) reOrientate();
@@ -345,7 +345,7 @@ FixedComp::createUnitVector(const Geometry::Vec3D& OG,
   Y=YAxis.unit();
   Z=ZAxis.unit();
   X=Y*Z;
-  
+
   makeOrthogonal();
   Origin=OG;
   if (primeAxis>0) reOrientate();
@@ -376,7 +376,7 @@ FixedComp::createUnitVector(const Geometry::Vec3D& OG,
   if (primeAxis>0) reOrientate();
   return;
 }
-  
+
 void
 FixedComp::makeOrthogonal()
   /*!
@@ -388,7 +388,7 @@ FixedComp::makeOrthogonal()
   ELog::RegMethod RegA("FixedComp","makeOrthogonal");
 
   // Use this later
-  const double XYcos=X.dotProd(Y); 
+  const double XYcos=X.dotProd(Y);
   if (std::abs<double>(XYcos)<Geometry::zeroTol &&
       std::abs(X.dotProd(Z))<Geometry::zeroTol &&
       std::abs(Y.dotProd(Z))<Geometry::zeroTol)
@@ -450,13 +450,13 @@ void
 FixedComp::reOrientate()
   /*!
     Calling function to reOrientate
-    This allows a primary axis to be-reorientated to 
-    a previously given direction. Typically used to 
+    This allows a primary axis to be-reorientated to
+    a previously given direction. Typically used to
     set an object to the vertical etc, after moving the object
   */
 {
   ELog::RegMethod RegA("FixedComp","reOrientate");
-  
+
   if (primeAxis>0)
     reOrientate(static_cast<size_t>(primeAxis)-1,orientateAxis);
   else if (primeAxis<0)
@@ -479,11 +479,11 @@ FixedComp::reOrientate(const size_t index,
    */
 {
   ELog::RegMethod RegA("FixedComp","reOrientate");
-  
+
   if (index>=3)
     throw ColErr::IndexError<size_t>(index,3,"index -- 3D vectors required");
-  
-  const Geometry::Vec3D axisDir(ADir.unit());  
+
+  const Geometry::Vec3D axisDir(ADir.unit());
 
   std::vector<Geometry::Vec3D*> AVec({&X,&Y,&Z});
 
@@ -496,10 +496,10 @@ FixedComp::reOrientate(const size_t index,
         *A *=-1;
       return;
     }
-  
+
   // Calc normal
   const Geometry::Vec3D n=axisDir * *AVec[index];
-  
+
   const double rotAngle=acos(cosTheta);
   const Geometry::Quaternion QR
     (Geometry::Quaternion::calcQRot(-rotAngle,n));
@@ -509,7 +509,7 @@ FixedComp::reOrientate(const size_t index,
   *AVec[index]=axisDir;
   return;
 }
-  
+
 void
 FixedComp::computeZOffPlane(const Geometry::Vec3D& XAxis,
                             const Geometry::Vec3D& YAxis,
@@ -524,7 +524,7 @@ FixedComp::computeZOffPlane(const Geometry::Vec3D& XAxis,
   ELog::RegMethod RegA("FixedComp","computeZOffPlane");
 
   const double XPart=XAxis.dotProd(YAxis);
-  
+
   Geometry::Vec3D YPrime=YAxis-XAxis*XPart;
 
   if (YPrime.abs()<Geometry::zeroTol)
@@ -580,11 +580,11 @@ FixedComp::applyAngleRotate(const double xAngle,
     Geometry::Quaternion::calcQRotDeg(xAngle,X);
   Qz.rotate(Y);
   Qz.rotate(X);
-  
+
   Qy.rotate(X);
   Qy.rotate(Y);
   Qy.rotate(Z);
-  
+
   Qx.rotate(X);
   Qx.rotate(Y);
   Qx.rotate(Z);
@@ -633,7 +633,7 @@ FixedComp::linkShift(const size_t sideIndex,
 
   Geometry::Vec3D Pt(LItem.getConnectPt());
   LItem.setConnectPt(Pt+X*xStep+Y*yStep+Z*zStep);
-  
+
   return;
 }
 
@@ -643,7 +643,7 @@ FixedComp::linkAngleRotate(const size_t sideIndex,
 			   const double zAngle)
  /*!
    Rotate a link point axis [not connection point]
-   \param sideIndex :: signed ink point 
+   \param sideIndex :: signed ink point
    \param xyAngle :: XY Rotation [second]
    \param zAngle :: Z Rotation [first]
  */
@@ -661,7 +661,7 @@ FixedComp::linkAngleRotate(const size_t sideIndex,
   Qz.rotate(Axis);
   Qxy.rotate(Axis);
   LItem.setAxis(Axis);
-  
+
   return;
 }
 
@@ -672,7 +672,7 @@ FixedComp::linkAngleRotate(const size_t sideIndex,
 			   const double zAngle)
  /*!
    Rotate a link point axis [not connection point]
-   \param sideIndex :: signed ink point 
+   \param sideIndex :: signed ink point
    \param xAngle :: X Rotation [third]
    \param xAngle :: Y Rotation [second]
    \param zAngle :: Z Rotation [first]
@@ -694,7 +694,7 @@ FixedComp::linkAngleRotate(const size_t sideIndex,
   Qy.rotate(Axis);
   Qx.rotate(Axis);
   LItem.setAxis(Axis);
-  
+
   return;
 }
 
@@ -720,11 +720,11 @@ FixedComp::applyFullRotate(const double xAngle,
 
   Qz.rotate(Y);
   Qz.rotate(X);
-  
+
   Qy.rotate(X);
   Qy.rotate(Y);
   Qy.rotate(Z);
-  
+
   Qx.rotate(X);
   Qx.rotate(Y);
   Qx.rotate(Z);
@@ -790,7 +790,7 @@ FixedComp::reverseZ()
 }
 
 void
-FixedComp::setNConnect(const size_t N) 
+FixedComp::setNConnect(const size_t N)
   /*!
     Create/Remove new links point
     \param N :: New size of link points
@@ -818,7 +818,7 @@ FixedComp::copyLinkObjects(const FixedComp& A)
 }
 
 void
-FixedComp::addLinkSurf(const size_t Index,const int SN) 
+FixedComp::addLinkSurf(const size_t Index,const int SN)
   /*!
     Add a surface to output
     \param Index :: Link number
@@ -828,14 +828,14 @@ FixedComp::addLinkSurf(const size_t Index,const int SN)
   ELog::RegMethod RegA("FixedComp","addLinkSurf(int)");
   if (Index>=LU.size())
     throw ColErr::IndexError<size_t>(Index,LU.size(),"LU size/Index");
-  
+
   LU[Index].addLinkSurf(SN);
   return;
 }
 
 void
 FixedComp::addLinkSurf(const size_t Index,
-		       const std::string& SList) 
+		       const std::string& SList)
   /*!
     Add a surface to output
     \param Index :: Link number
@@ -851,7 +851,7 @@ FixedComp::addLinkSurf(const size_t Index,
 }
 
 void
-FixedComp::addLinkSurf(const size_t Index,const HeadRule& HR) 
+FixedComp::addLinkSurf(const size_t Index,const HeadRule& HR)
   /*!
     Add a surface to output
     \param Index :: Link number
@@ -861,13 +861,13 @@ FixedComp::addLinkSurf(const size_t Index,const HeadRule& HR)
   ELog::RegMethod RegA("FixedComp","addLinkSurf(HeadRule)");
   if (Index>=LU.size())
     throw ColErr::IndexError<size_t>(Index,LU.size(),"LU size/Index");
-  
+
   LU[Index].addLinkSurf(HR);
   return;
 }
 
 void
-FixedComp::addLinkComp(const size_t Index,const int SN) 
+FixedComp::addLinkComp(const size_t Index,const int SN)
   /*!
     Add a surface to output
     \param Index :: Link number
@@ -877,14 +877,14 @@ FixedComp::addLinkComp(const size_t Index,const int SN)
   ELog::RegMethod RegA("FixedComp","addLinkComp(int)");
   if (Index>=LU.size())
     throw ColErr::IndexError<size_t>(Index,LU.size(),"LU size/Index");
-  
+
   LU[Index].addLinkComp(SN);
   return;
 }
 
 void
 FixedComp::addLinkComp(const size_t Index,
-		       const std::string& SList) 
+		       const std::string& SList)
   /*!
     Add a surface to output
     \param Index :: Link number
@@ -900,7 +900,7 @@ FixedComp::addLinkComp(const size_t Index,
 }
 
 void
-FixedComp::addLinkComp(const size_t Index,const HeadRule& HR) 
+FixedComp::addLinkComp(const size_t Index,const HeadRule& HR)
   /*!
     Add a surface to output
     \param Index :: Link number
@@ -910,7 +910,7 @@ FixedComp::addLinkComp(const size_t Index,const HeadRule& HR)
   ELog::RegMethod RegA("FixedComp","addLinkComp(HeadRule)");
   if (Index>=LU.size())
     throw ColErr::IndexError<size_t>(Index,LU.size(),"LU size/Index");
-  
+
   LU[Index].addLinkComp(HR);
   return;
 }
@@ -919,7 +919,7 @@ template<typename T>
 void
 FixedComp::setNamedLinkSurf(const size_t Index,
 			    const std::string& linkName,
-			    const T& SUnit) 
+			    const T& SUnit)
   /*!
     Set a surface to output and set the link name
     \param Index :: Link number
@@ -935,7 +935,7 @@ FixedComp::setNamedLinkSurf(const size_t Index,
 }
 
 void
-FixedComp::setLinkSurf(const size_t Index,const int SN) 
+FixedComp::setLinkSurf(const size_t Index,const int SN)
   /*!
     Set  a surface to output
     \param Index :: Link number
@@ -952,7 +952,7 @@ FixedComp::setLinkSurf(const size_t Index,const int SN)
 
 void
 FixedComp::setLinkSurf(const size_t Index,
-		       const std::string& SList) 
+		       const std::string& SList)
   /*!
     Set a surface to output
     \param Index :: Link number
@@ -969,7 +969,7 @@ FixedComp::setLinkSurf(const size_t Index,
 
 void
 FixedComp::setLinkSurf(const size_t Index,
-		       const HeadRule& HR) 
+		       const HeadRule& HR)
   /*!
     Set a surface to output
     \param Index :: Link number
@@ -985,7 +985,7 @@ FixedComp::setLinkSurf(const size_t Index,
 }
 
 void
-FixedComp::setLinkComp(const size_t Index,const int SN) 
+FixedComp::setLinkComp(const size_t Index,const int SN)
   /*!
     Set a surface to output (in complement)
     \param Index :: Link number
@@ -1002,7 +1002,7 @@ FixedComp::setLinkComp(const size_t Index,const int SN)
 
 void
 FixedComp::setLinkComp(const size_t Index,
-		       const std::string& SList) 
+		       const std::string& SList)
   /*!
     Set a surface to output inc complement
     \param Index :: Link number
@@ -1020,7 +1020,7 @@ FixedComp::setLinkComp(const size_t Index,
 
 void
 FixedComp::setLinkComp(const size_t Index,
-		       const HeadRule& HR) 
+		       const HeadRule& HR)
   /*!
     Set a surface to output in complement
     \param Index :: Link number
@@ -1039,7 +1039,7 @@ FixedComp::setLinkComp(const size_t Index,
 void
 FixedComp::setLinkSurf(const size_t Index,const HeadRule& HR,
 		       const bool compFlag,const HeadRule& BR,
-		       const bool bridgeCompFlag) 
+		       const bool bridgeCompFlag)
   /*!
     Set a link surface based on both a rule and
     a bridging rule
@@ -1073,7 +1073,7 @@ FixedComp::setLinkSurf(const size_t Index,const HeadRule& HR,
 
 
 void
-FixedComp::setBridgeSurf(const size_t Index,const int SN) 
+FixedComp::setBridgeSurf(const size_t Index,const int SN)
   /*!
     Set a surface to bridge output
     \param Index :: Link number
@@ -1089,7 +1089,7 @@ FixedComp::setBridgeSurf(const size_t Index,const int SN)
 }
 
 void
-FixedComp::setBridgeSurf(const size_t Index,const HeadRule& HR) 
+FixedComp::setBridgeSurf(const size_t Index,const HeadRule& HR)
   /*!
     Set a surface to bridge output
     \param Index :: Link number
@@ -1106,7 +1106,7 @@ FixedComp::setBridgeSurf(const size_t Index,const HeadRule& HR)
 }
 
 void
-FixedComp::addBridgeSurf(const size_t Index,const int SN) 
+FixedComp::addBridgeSurf(const size_t Index,const int SN)
   /*!
     Add a surface to output
     \param Index :: Link number
@@ -1116,7 +1116,7 @@ FixedComp::addBridgeSurf(const size_t Index,const int SN)
   ELog::RegMethod RegA("FixedComp","addBridgeSurf");
   if (Index>=LU.size())
     throw ColErr::IndexError<size_t>(Index,LU.size(),"LU size/Index");
-  
+
   LU[Index].addBridgeSurf(SN);
   return;
 }
@@ -1125,7 +1125,7 @@ FixedComp::addBridgeSurf(const size_t Index,const int SN)
 
 void
 FixedComp::addBridgeSurf(const size_t Index,
-			 const std::string& SList) 
+			 const std::string& SList)
   /*!
     Add a surface to output
     \param Index :: Link number
@@ -1181,7 +1181,7 @@ FixedComp::setLineConnect(const size_t Index,
   LinkUnit& LObj=LU[Index];
   LObj.populateSurf();
   const Geometry::Vec3D Pt=
-    SurInter::getLinePoint(C,A,LObj.getMain(),LObj.getCommon()); 
+    SurInter::getLinePoint(C,A,LObj.getMain(),LObj.getCommon());
   LObj.setConnectPt(Pt);
   LObj.setAxis(A);
 
@@ -1193,7 +1193,7 @@ FixedComp::setUSLinkComplement(const size_t Index,
 			       const FixedComp& FC,
 			       const size_t sideIndex)
   /*!
-    Copy the opposite (as if joined) link surface 
+    Copy the opposite (as if joined) link surface
     Note that the surfaces are complemented
     \param Index :: Link number
     \param FC :: Other Fixed component to copy object from
@@ -1206,7 +1206,7 @@ FixedComp::setUSLinkComplement(const size_t Index,
     throw ColErr::IndexError<size_t>(Index,LU.size(),"LU size/index");
   if (sideIndex>=FC.LU.size())
     throw ColErr::IndexError<size_t>(sideIndex,FC.LU.size(),"FC/index");
-  
+
   LU[Index]=FC.LU[sideIndex];
   LU[Index].complement();
   return;
@@ -1217,7 +1217,7 @@ FixedComp::setUSLinkCopy(const size_t Index,
 		       const FixedComp& FC,
 		       const size_t sideIndex)
   /*!
-    Copy the opposite (as if joined) link surface 
+    Copy the opposite (as if joined) link surface
     Note that the surfaces are complemented
     \param Index :: Link number
     \param FC :: Other Fixed component to copy object from
@@ -1229,8 +1229,8 @@ FixedComp::setUSLinkCopy(const size_t Index,
     throw ColErr::IndexError<size_t>(Index,LU.size(),"LU size/index");
   if (sideIndex>=FC.LU.size())
     throw ColErr::IndexError<size_t>(sideIndex,FC.LU.size(),"FC/index");
-  
-  LU[Index]=FC.LU[sideIndex];	
+
+  LU[Index]=FC.LU[sideIndex];
   return;
 }
 
@@ -1239,7 +1239,7 @@ FixedComp::setLinkCopy(const size_t Index,
 		       const FixedComp& FC,
 		       const std::string& sideName)
   /*!
-    Copy the opposite (as if joined) link surface 
+    Copy the opposite (as if joined) link surface
     Note that the surfaces are complemented
     \param Index :: Link number
     \param FC :: Other Fixed component to copy object from
@@ -1257,7 +1257,7 @@ FixedComp::setLinkCopy(const size_t Index,
 		       const FixedComp& FC,
 		       const long int sideIndex)
   /*!
-    Copy the opposite (as if joined) link surface 
+    Copy the opposite (as if joined) link surface
     Note that the surfaces are complemented
     \param Index :: Link number
     \param FC :: Other Fixed component to copy object from
@@ -1284,7 +1284,7 @@ FixedComp::setLinkCopy(const std::string& indexName,
 		       const FixedComp& FC,
 		       const std::string& sideName)
   /*!
-    Copy the opposite (as if joined) link surface 
+    Copy the opposite (as if joined) link surface
     Note that the surfaces are complemented
     \param indexName :: Link index number
     \param FC :: Other Fixed component to copy object from
@@ -1296,7 +1296,7 @@ FixedComp::setLinkCopy(const std::string& indexName,
   const long int LI=getSideIndex(indexName);
   if (!LI)
     throw ColErr::InContainerError<std::string>(indexName,"indexName zero");
-  
+
   const size_t Index=static_cast<size_t>(std::abs(LI-1));
   setLinkCopy(Index,FC,FC.getSideIndex(sideName));
   return;
@@ -1307,7 +1307,7 @@ FixedComp::setLinkCopy(const std::string& indexName,
 		       const FixedComp& FC,
 		       const long int sideIndex)
   /*!
-    Copy the opposite (as if joined) link surface 
+    Copy the opposite (as if joined) link surface
     Note that the surfaces are complemented
     \param indexame :: Link index number
     \param FC :: Other Fixed component to copy object from
@@ -1321,7 +1321,7 @@ FixedComp::setLinkCopy(const std::string& indexName,
   if (!LI)
     throw ColErr::InContainerError<std::string>
         (indexName,"FC["+keyName+"]::indexName zero");
-  
+
   const size_t Index=static_cast<size_t>(std::abs(LI-1));
   setLinkCopy(Index,FC,sideIndex);
   return;
@@ -1341,7 +1341,7 @@ FixedComp::setBasicExtent(const double XWidth,const double YWidth,
   if (LU.size()!=6)
     throw ColErr::MisMatch<int>(6,static_cast<int>(LU.size()),
 				"6/LU.size");
-  
+
 
   LU[0].setConnectPt(Origin-Y*XWidth);
   LU[1].setConnectPt(Origin+Y*XWidth);
@@ -1391,7 +1391,7 @@ FixedComp::getLU(const size_t Index) const
 }
 
 LinkUnit&
-FixedComp::getLU(const size_t Index) 
+FixedComp::getLU(const size_t Index)
  /*!
    Get the axis of the linked component
    \param Index :: Link number
@@ -1410,7 +1410,7 @@ FixedComp::getSignedRefLU(const long int sideIndex) const
   /*!
     Accessor to the link unit
     \param sideIndex :: SIGNED +1 side index
-    \return Link Unit 
+    \return Link Unit
   */
 {
   ELog::RegMethod RegA("FixedComp","getSignedRefLU:"+keyName);
@@ -1433,7 +1433,7 @@ FixedComp::getSignedLU(const long int sideIndex) const
     Accessor to the link unit but for negative sideIndex
     the linke point in inverted
     \param sideIndex :: SIGNED +1 side index
-    \return Link Unit 
+    \return Link Unit
   */
 {
   ELog::RegMethod RegA("FixedComp","getSignedLU:"+keyName);
@@ -1460,7 +1460,7 @@ FixedComp::getSignedLU(const long int sideIndex) const
 }
 
 
-  
+
 int
 FixedComp::getUSLinkSurf(const size_t Index) const
   /*!
@@ -1472,7 +1472,7 @@ FixedComp::getUSLinkSurf(const size_t Index) const
   ELog::RegMethod RegA("FixedComp","getUSLinkSurf");
   if (Index>=LU.size())
     throw ColErr::IndexError<size_t>(Index,LU.size(),"Index to big");
-  
+
   return LU[Index].getLinkSurf();
 }
 
@@ -1496,7 +1496,7 @@ FixedComp::nameSideIndex(const size_t lP,
     }
   else
     keyMap.emplace(linkName,lP);
-  
+
   return;
 }
 
@@ -1514,13 +1514,13 @@ FixedComp::nameSideIndex(const std::map<std::string,size_t>& linkMap)
 
   return;
 }
-  
+
 std::string
 FixedComp::getSideName(const long int sideIndex) const
   /*!
     Find the name based on the index.
-    \param sideName :: Name with +/- at front if require to change 
-    \return name 
+    \param sideName :: Name with +/- at front if require to change
+    \return name
   */
 {
   ELog::RegMethod RegA("FixedComp","getSideIndex");
@@ -1549,7 +1549,7 @@ long int
 FixedComp::getSideIndex(const std::string& sideName) const
   /*!
     Find the sideIndex from the name
-    \param sideName :: Name with +/- at front if require to change 
+    \param sideName :: Name with +/- at front if require to change
     \return sideIndex which is signed
   */
 {
@@ -1564,17 +1564,17 @@ FixedComp::getSideIndex(const std::string& sideName) const
 
       const long int negScale
 	((sideName[0]=='-' || sideName[0]=='#') ? -1 : 1);
-	 
+
       const std::string partName=
         (sideName[0]=='+' || sideName[0]=='-' || sideName[0]=='#') ?
            sideName.substr(1) : sideName;
 
       std::map<std::string,size_t>::const_iterator mc=
         keyMap.find(partName);
-      
+
       if (mc!=keyMap.end())
         return negScale*static_cast<long int>(mc->second+1);
-      
+
       if (partName=="Origin" || partName=="origin")
         return 0;
     }
@@ -1585,8 +1585,8 @@ FixedComp::getSideIndex(const std::string& sideName) const
 bool
 FixedComp::hasSideIndex(const std::string& sideName) const
   /*!
-    Find the object has a side index AND is complete 
-    \param sideName :: Name with +/- at front if require to change 
+    Find the object has a side index AND is complete
+    \param sideName :: Name with +/- at front if require to change
     \return true if possible
   */
 {
@@ -1612,11 +1612,11 @@ FixedComp::hasSideIndex(const std::string& sideName) const
 
       std::map<std::string,size_t>::const_iterator mc=
         keyMap.find(partName);
-      lp= (mc!=keyMap.end()) ?  mc->second : LU.size();      
+      lp= (mc!=keyMap.end()) ?  mc->second : LU.size();
     }
   return (lp<LU.size()) ? LU[lp].isComplete() : 0;
 }
-  
+
 std::vector<Geometry::Vec3D>
 FixedComp::getAllLinkPts() const
   /*!
@@ -1627,7 +1627,7 @@ FixedComp::getAllLinkPts() const
   ELog::RegMethod RegA("FixedComp","getAllLinkPts:"+keyName);
 
   std::vector<Geometry::Vec3D> LPout;
-  
+
   for(const LinkUnit& lunit : LU)
     LPout.push_back(lunit.getConnectPt());
 
@@ -1639,7 +1639,7 @@ FixedComp::getLinkDistance(const std::string& AName,
                            const std::string& BName) const
   /*!
     Accessor to the distance between link points
-    \param AName :: Link name 
+    \param AName :: Link name
     \param BName :: link name
     \return Distance between points
   */
@@ -1655,7 +1655,7 @@ FixedComp::getLinkDistance(const long int AIndex,
   /*!
     Accessor to the distance between link points
     \param AIndex :: SIGNED +1 side index
-    \param BIndex :: SIGNED +1 side index 
+    \param BIndex :: SIGNED +1 side index
     \return Distance between points
   */
 {
@@ -1673,7 +1673,7 @@ FixedComp::getLinkDistance(const long int AIndex,
     Accessor to the distance between link points
     \param AIndex :: SIGNED +1 side index
     \param FC :: FixedComp to use
-    \param BIndex :: SIGNED +1 side index 
+    \param BIndex :: SIGNED +1 side index
     \return Distance between points
   */
 {
@@ -1687,7 +1687,7 @@ FixedComp::hasLinkPt(const std::string& sideName) const
   /*!
     Accessor to the link point
     \param sideName :: named link point
-    \return True if link point set 
+    \return True if link point set
   */
 {
   ELog::RegMethod RegA("FixedComp","getLinkPt[str]:"+keyName);
@@ -1784,7 +1784,7 @@ FixedComp::getLinkAxis(const std::string& sideName) const
   const long int sideIndex =getSideIndex(sideName);
   return getLinkAxis(sideIndex);
 }
-  
+
 Geometry::Vec3D
 FixedComp::getLinkPt(const long int sideIndex) const
   /*!
@@ -1822,7 +1822,7 @@ FixedComp::getLinkSurf(const long int sideIndex) const
 {
   ELog::RegMethod RegA("FixedComp","getLinkSurf");
   if (!sideIndex) return 0;
-  
+
   const LinkUnit& LItem=getSignedRefLU(sideIndex);
   const int sign((sideIndex>0) ? 1 : -1);
   return sign*LItem.getLinkSurf();
@@ -1841,7 +1841,7 @@ FixedComp::getLinkAxis(const long int sideIndex) const
 
   if (sideIndex==0)
     return Y;
-  
+
   const LinkUnit& LItem=getSignedRefLU(sideIndex);
   return (sideIndex>0)  ? LItem.getAxis() : -LItem.getAxis();
 }
@@ -1857,7 +1857,7 @@ FixedComp::getLinkZAxis(const long int sideIndex) const
   ELog::RegMethod RegA("FixedComp","getLinkZAxis");
 
   if (sideIndex==0) return Z;
-      
+
   const Geometry::Vec3D yTest=getLinkAxis(sideIndex);
   Geometry::Vec3D zTest=Z;
   Geometry::Vec3D xTest=X;
@@ -1877,13 +1877,13 @@ FixedComp::getLinkZAxis(const long int sideIndex) const
 //   /*!
 //     Accessor to the link string
 //     \param sideIndex :: SIGNED +1 side index
-//     \return Link string 
+//     \return Link string
 //   */
 // {
 //   ELog::RegMethod RegA("FixedComp","getLinkString:"+keyName);
 
 //   if (!sideIndex) return "";
-  
+
 //   const size_t linkIndex=
 //     (sideIndex>0) ? static_cast<size_t>(sideIndex-1) :
 //     static_cast<size_t>(-sideIndex-1) ;
@@ -1891,7 +1891,7 @@ FixedComp::getLinkZAxis(const long int sideIndex) const
 //   return (sideIndex>0) ?
 //     getUSLinkString(linkIndex) : getUSLinkComplement(linkIndex);
 // }
-  
+
 HeadRule
 FixedComp::getUSLink(const size_t Index) const
 /*!
@@ -1903,7 +1903,7 @@ FixedComp::getUSLink(const size_t Index) const
   ELog::RegMethod RegA("FixedComp","getUSLink");
   if (Index>=LU.size())
     throw ColErr::IndexError<size_t>(Index,LU.size(),"Index/LU.size");
-  
+
   return LU[Index].getLink();
 }
 
@@ -1922,12 +1922,12 @@ FixedComp::getUSLink(const size_t Index) const
 //   HeadRule RP;
 //   RP.procString(LU[Index].getMain());
 //   RP.makeComplement();
-  
+
 //   RP.addIntersection(LU[Index].getCommon().display());
 //   return RP.display();
 // }
 
-void 
+void
 FixedComp::setCentre(const Geometry::Vec3D& C)
   /*!
     User Interface to LU[1] to set Point + Axis
@@ -1939,9 +1939,9 @@ FixedComp::setCentre(const Geometry::Vec3D& C)
 }
 
 const Geometry::Vec3D&
-FixedComp::getExit() const 
+FixedComp::getExit() const
   /*!
-    User Interface to LU[1] to get Point 
+    User Interface to LU[1] to get Point
     \return connect point
   */
 {
@@ -1953,10 +1953,10 @@ FixedComp::getExit() const
   return LU[1].getConnectPt();
 }
 
-void 
+void
 FixedComp::setExit(const int surfN,
 		   const Geometry::Vec3D& C,
-		   const Geometry::Vec3D& A) 
+		   const Geometry::Vec3D& A)
   /*!
     User Interface to LU[1] to set Point + Axis
     \param C :: Connect point
@@ -1971,9 +1971,9 @@ FixedComp::setExit(const int surfN,
   return;
 }
 
-void 
+void
 FixedComp::setExit(const Geometry::Vec3D& C,
-		   const Geometry::Vec3D& A) 
+		   const Geometry::Vec3D& A)
   /*!
     User Interface to LU[1] to set Point + Axis
     \param C :: Connect point
@@ -1996,7 +1996,7 @@ FixedComp::findLinkAxis(const Geometry::Vec3D& AX) const
   ELog::RegMethod RegA("FixedComp","findLinkAxis");
 
   long int outIndex(0);
-  double maxValue(-1.0);  
+  double maxValue(-1.0);
   for(size_t i=0;i<LU.size();i++)
     {
       const double MX=AX.dotProd(LU[i].getAxis());
@@ -2008,13 +2008,13 @@ FixedComp::findLinkAxis(const Geometry::Vec3D& AX) const
     }
   return outIndex;
 }
-  
+
 void
 FixedComp::applyRotation(const Geometry::Vec3D& Axis,
 			 const double Angle)
   /*!
     Apply a rotation to the basis set
-    \param Axis :: rotation axis 
+    \param Axis :: rotation axis
     \param Angle :: rotation angle
   */
 {
@@ -2022,7 +2022,7 @@ FixedComp::applyRotation(const Geometry::Vec3D& Axis,
 
   const Geometry::Quaternion Qrot=
     Geometry::Quaternion::calcQRotDeg(Angle,Axis.unit());
-  
+
   Qrot.rotate(X);
   Qrot.rotate(Y);
   Qrot.rotate(Z);
@@ -2034,7 +2034,7 @@ FixedComp::getFullRule(const std::string& linkName) const
   /*!
     Get Full rule based on link name
     \param linkName :: Name of link point
-    \return Main HeadRule    
+    \return Main HeadRule
   */
 {
   ELog::RegMethod RegA("FixedComp","getFullRule(str)");
@@ -2049,10 +2049,10 @@ FixedComp::getFullRule(const long int sideIndex) const
     \return Main HeadRule
    */
 {
-  ELog::RegMethod RegA("FixedComp","getFullRule"); 
+  ELog::RegMethod RegA("FixedComp","getFullRule");
 
   const LinkUnit& LObj=getSignedRefLU(sideIndex);
-  HeadRule Out=(sideIndex>0) ? 
+  HeadRule Out=(sideIndex>0) ?
     LObj.getMain() :
     LObj.getMain().complement();
 
@@ -2066,13 +2066,13 @@ FixedComp::getMainRule(const std::string& linkName) const
   /*!
     Get Main rule based on link name
     \param linkName :: Name of link point
-    \return Main HeadRule    
+    \return Main HeadRule
   */
 {
   ELog::RegMethod RegA("FixedComp","getMainRule(str)");
   return getMainRule(getSideIndex(linkName));
 }
-  
+
 HeadRule
 FixedComp::getMainRule(const long int sideIndex) const
   /*!
@@ -2081,10 +2081,10 @@ FixedComp::getMainRule(const long int sideIndex) const
     \return Main HeadRule
    */
 {
-  ELog::RegMethod RegA("FixedComp","getMainRule"); 
+  ELog::RegMethod RegA("FixedComp","getMainRule");
 
   const LinkUnit& LObj=getSignedRefLU(sideIndex);
-  return (sideIndex>0) ? 
+  return (sideIndex>0) ?
     LObj.getMain() :
     LObj.getMain().complement();
 }
@@ -2098,11 +2098,11 @@ FixedComp::getUSMainRule(const size_t Index) const
     \return Main HeadRule
    */
 {
-  ELog::RegMethod RegA("FixedComp","getUSMainRule"); 
+  ELog::RegMethod RegA("FixedComp","getUSMainRule");
 
   if (Index>=LU.size())
     throw ColErr::IndexError<size_t>(Index,LU.size(),"Index/LU.size");
-  
+
   return LU[Index].getMain();
 }
 
@@ -2111,13 +2111,13 @@ FixedComp::getCommonRule(const std::string& linkName) const
   /*!
     Get Common rule based on link name
     \param linkName :: Name of link point
-    \return Common HeadRule    
+    \return Common HeadRule
   */
 {
   ELog::RegMethod RegA("FixedComp","getCommonRule(str)");
   return getCommonRule(getSideIndex(linkName));
 }
-  
+
 HeadRule
 FixedComp::getCommonRule(const long int sideIndex) const
   /*!
@@ -2126,7 +2126,7 @@ FixedComp::getCommonRule(const long int sideIndex) const
     \return Main HeadRule
   */
 {
-  ELog::RegMethod RegA("FixedComp","getCommonRule(long int)"); 
+  ELog::RegMethod RegA("FixedComp","getCommonRule(long int)");
 
   const LinkUnit& LObj=getSignedRefLU(sideIndex);
   return LObj.getCommon();
@@ -2137,14 +2137,14 @@ FixedComp::getUSCommonRule(const size_t Index) const
   /*!
     Get the common rule.
     \param Index :: Index for link unit
-    \return Common Headrule 
+    \return Common Headrule
    */
 {
-  ELog::RegMethod RegA("FixedComp","getUSCommonRule"); 
+  ELog::RegMethod RegA("FixedComp","getUSCommonRule");
 
   if (Index>=LU.size())
     throw ColErr::IndexError<size_t>(Index,LU.size(),"Index/LU.size");
-  
+
   return LU[Index].getCommon();
 }
 
@@ -2154,8 +2154,9 @@ FixedComp::calcLinkAxis(const long int sideIndex,
 			Geometry::Vec3D& YVec,
 			Geometry::Vec3D& ZVec) const
   /*!
-    Given a sideIndex calculate the axises at that point.
-    biasing the prefrence to select Z relative to 
+    Calculate a complete orthogonal coordinate system (X, Y, and Z unit vectors)
+    for a specific link point using the link's own axis as the primary direction (Y-axis).
+
     \param sideIndex :: Signed side+1 (zero for origin of FC)
     \param XVec :: Output X Vec
     \param YVec :: Output Y Vec
@@ -2175,7 +2176,7 @@ FixedComp::calcLinkAxis(const long int sideIndex,
   // Y not parallel to Z case
   const double ZdotYVec=Z.dotProd(YVec);
 
-  
+
   const Geometry::Vec3D& ZPrime=
     (fabs(ZdotYVec) < 1.0-Geometry::zeroTol) ? Z : X;
 
@@ -2204,10 +2205,10 @@ FixedComp::applyRotation(const localRotate& LR)
   LR.applyFullAxis(X);
   LR.applyFullAxis(Y);
   LR.applyFullAxis(Z);
-  
+
   for(LinkUnit& linkItem : LU)
     linkItem.applyRotation(LR);
-  
+
   return;
 }
 
@@ -2215,7 +2216,7 @@ int
 FixedComp::getExitWindow(const long int sideIndex,
 			 std::vector<int>& window) const
   /*!
-    Generic exit window system : 
+    Generic exit window system :
     -- Requires at least 6 surfaces
     -- Requires 3-6 to be sign surf
     \param sideIndex :: Link point
@@ -2230,7 +2231,7 @@ FixedComp::getExitWindow(const long int sideIndex,
   const size_t outIndex((sideIndex>0) ?
 			static_cast<size_t>(sideIndex)-1 :
 			static_cast<size_t>(-sideIndex)-1);
-			
+
   if (outIndex>LU.size())
     throw ColErr::IndexError<size_t>(outIndex,6,"outIndex too big");
 
@@ -2259,7 +2260,7 @@ FixedComp::getExitWindow(const long int sideIndex,
   const Geometry::Vec3D& bX=LU[1].getAxis();
   const Geometry::Vec3D& cX=LU[2].getAxis();
 
-  
+
   if (std::abs<double>(aX.dotProd(bX))>0.99)
     std::swap(window[1],window[2]);
   else if (std::abs<double>(bX.dotProd(cX))>0.99)
@@ -2284,7 +2285,7 @@ FixedComp::getExitWindow(const long int sideIndex,
 	  break;
 	}
     }
-    
+
   return primOutSurf;
 }
 
@@ -2299,7 +2300,7 @@ FixedComp::createAll(Simulation&,const FixedComp& FC,
   */
 {
   ELog::RegMethod RegA("FixedComp","createAll(FC)");
-  
+
   throw ColErr::AbsObjMethod("Single FC["+FC.keyName+"]"+
 			     " Function not implemented");
 }
@@ -2316,7 +2317,7 @@ FixedComp::createAll(Simulation&,
   */
 {
   ELog::RegMethod RegA("FixedComp","createAll(FC,FC)");
-  
+
   throw ColErr::AbsObjMethod("Double FC["+FCA.keyName+"]"+
 			     "FC["+FCB.keyName+"]"+
 			     " Function not implemented");
@@ -2334,7 +2335,7 @@ FixedComp::createAll(Simulation& System,
   */
 {
   ELog::RegMethod RegA("FixedComp","createAll(Named)");
-  
+
   this->createAll(System,FC,FC.getSideIndex(linkName));
   return;
 }
@@ -2358,7 +2359,7 @@ FixedComp::createAll(Simulation& System,
   */
 {
   ELog::RegMethod RegA("FixedComp","createAll(Named,Named)");
-  
+
   this->createAll(System,
 		  FCA,FCA.getSideIndex(linkNameA),
 		  FCB,FCB.getSideIndex(linkNameB));
@@ -2402,7 +2403,7 @@ FixedComp::createAll(Simulation& System,
   */
 {
   ELog::RegMethod RegA("FixedComp","createAll(FG,group,index)");
-  
+
   this->createAll(System,FG.getKey(groupName),sideIndex);
   return;
 }

--- a/System/attachComp/FixedComp.cxx
+++ b/System/attachComp/FixedComp.cxx
@@ -1575,7 +1575,7 @@ FixedComp::getSideIndex(const std::string& sideName) const
       if (mc!=keyMap.end())
         return negScale*static_cast<long int>(mc->second+1);
 
-      if (partName=="Origin" || partName=="origin")
+      if (partName=="Origin" || partName=="origin") // TODO: move above previous if?
         return 0;
     }
   throw ColErr::InContainerError<std::string>

--- a/System/attachCompInc/FixedComp.h
+++ b/System/attachCompInc/FixedComp.h
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   attachCompInc/FixedComp.h
  *
  * Copyright (c) 2004-2023 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #ifndef attachSystem_FixedComp_h
@@ -37,7 +37,7 @@ class HeadRule;
 namespace attachSystem
 {
   class FixedGroup;
-  
+
 /*!
   \class FixedComp
   \version 1.0
@@ -46,43 +46,43 @@ namespace attachSystem
   \brief Component that is at a fixed position
 */
 
-class FixedComp  
+class FixedComp
 {
  private:
 
   HeadRule getUSLink(const size_t) const;
   HeadRule getUSLinkComplement(const size_t) const;
   int getUSLinkSurf(const size_t) const;
-  
+
  protected:
-  
+
   const std::string keyName;       ///< Key Name
   ModelSupport::surfRegister SMap; ///< Surface register
   const int buildIndex;            ///< Index of surface offset
-  int cellIndex;                   ///< Cell index    
+  int cellIndex;                   ///< Cell index
 
   std::map<std::string,size_t> keyMap; ///< Keynames to linkPt index
 
-  Geometry::Vec3D X;            ///< X-coordinate 
-  Geometry::Vec3D Y;            ///< Y-coordinate 
-  Geometry::Vec3D Z;            ///< Z-coordinate 
-  Geometry::Vec3D Origin;       ///< Origin  
+  Geometry::Vec3D X;            ///< X-coordinate
+  Geometry::Vec3D Y;            ///< Y-coordinate
+  Geometry::Vec3D Z;            ///< Z-coordinate
+  Geometry::Vec3D Origin;       ///< Origin
 
   Geometry::Vec3D orientateAxis; ///< Axis for reorientation
-  long int primeAxis;            ///< X/Y/Z Axis for reorientation 
+  long int primeAxis;            ///< X/Y/Z Axis for reorientation
 
   std::vector<LinkUnit> LU;     ///< Linked unit items
-  
+
   void makeOrthogonal();
 
   const HeadRule& getUSMainRule(const size_t) const;
   const HeadRule& getUSCommonRule(const size_t) const;
-  
+
   void setUSLinkComplement(const size_t,const FixedComp&,const size_t);
   void setUSLinkCopy(const size_t,const FixedComp&,const size_t);
 
   //  virtual std::string getLinkString(const long int) const;
-  
+
  public:
 
   static void computeZOffPlane(const Geometry::Vec3D&,
@@ -101,7 +101,7 @@ class FixedComp
   FixedComp& operator=(const FixedComp&);
   virtual ~FixedComp() {}     ///< Destructor
 
-  const LinkUnit& operator[](const size_t) const; 
+  const LinkUnit& operator[](const size_t) const;
 
   /// have cells been built
   bool hasActiveCells() const
@@ -109,7 +109,7 @@ class FixedComp
 
   void reOrientate();
   void reOrientate(const size_t,const Geometry::Vec3D&);
-  
+
   // Operator Set:
   virtual void createUnitVector(const FixedComp&);
   virtual void createUnitVector(const FixedComp&,const Geometry::Vec3D&);
@@ -123,7 +123,7 @@ class FixedComp
   virtual void createUnitVector(const Geometry::Vec3D&,
 				const Geometry::Vec3D&,
 				const Geometry::Vec3D&);
-  
+
   virtual void createUnitVector(const Geometry::Vec3D&,
 				const Geometry::Vec3D&,
 				const Geometry::Vec3D&,
@@ -148,7 +148,7 @@ class FixedComp
 
   void reverseX();
   void reverseZ();
-  
+
   void setConnect(const size_t,const Geometry::Vec3D&,const Geometry::Vec3D&);
   void setLineConnect(const size_t,const Geometry::Vec3D&,
 		      const Geometry::Vec3D&);
@@ -189,17 +189,17 @@ class FixedComp
 
   /// Get keyname
   const std::string& getKeyName() const { return keyName; }
-  /// Access X
-  const Geometry::Vec3D& getX() const { return X; }  
+  /// Access X direction
+  const Geometry::Vec3D& getX() const { return X; }
   /// Access Y direction
-  const Geometry::Vec3D& getY() const { return Y; }  
+  const Geometry::Vec3D& getY() const { return Y; }
   /// Access Z direction
   const Geometry::Vec3D& getZ() const { return Z; }
   /// Access centre
-  virtual const Geometry::Vec3D& getCentre() const  { return Origin; }  
+  virtual const Geometry::Vec3D& getCentre() const  { return Origin; }
   virtual int getExitWindow(const long int,std::vector<int>&) const;
   virtual const Geometry::Vec3D& getExit() const;
-  
+
   void nameSideIndex(const size_t,const std::string&);
   void nameSideIndex(const std::map<std::string,size_t>&);
   void copyLinkObjects(const FixedComp&);
@@ -210,12 +210,12 @@ class FixedComp
   const LinkUnit& getSignedRefLU(const long int)  const;
   const LinkUnit& getLU(const size_t)  const;
   LinkUnit& getLU(const size_t);
-  
+
   LinkUnit getSignedLU(const long int) const;
   bool hasSideIndex(const std::string&) const;
   long int getSideIndex(const std::string&) const;
   std::string getSideName(const long int) const;
-  
+
   std::vector<Geometry::Vec3D> getAllLinkPts() const;
 
   bool hasLinkPt(const long int) const;
@@ -223,15 +223,15 @@ class FixedComp
 
   bool hasLinkSurf(const long int) const;
   bool hasLinkSurf(const std::string&) const;
-  
+
   Geometry::Vec3D getLinkPt(const std::string&) const;
   Geometry::Vec3D getLinkAxis(const std::string&) const;
   int getLinkSurf(const std::string&) const;
-  
+
   Geometry::Vec3D getLinkPt(const long int) const;
   Geometry::Vec3D getLinkAxis(const long int) const;
   Geometry::Vec3D getLinkZAxis(const long int) const;
-  
+
 
   double getLinkDistance(const std::string&,const std::string&) const;
   double getLinkDistance(const long int,const long int) const;
@@ -247,7 +247,7 @@ class FixedComp
 
   HeadRule getCommonRule(const std::string&) const;
   HeadRule getCommonRule(const long int) const;
-  
+
   long int findLinkAxis(const Geometry::Vec3D&) const;
 
   /// access next cell if need
@@ -255,7 +255,7 @@ class FixedComp
   /// access next cell as needed
   int getNextCell() const { return cellIndex; }
 
-  
+
   void calcLinkAxis(const long int,Geometry::Vec3D&,
 		    Geometry::Vec3D&,Geometry::Vec3D&) const;
 
@@ -285,7 +285,7 @@ class FixedComp
   std::vector<int> splitObjectAbsolute
     (Simulation&,const int,const int,
      const Geometry::Vec3D&,const Geometry::Vec3D&);
-  
+
   std::vector<int> splitObjectAbsolute
     (Simulation&,const int,const int, const std::vector<Geometry::Vec3D>&,
      const std::vector<Geometry::Vec3D>&);
@@ -306,4 +306,3 @@ class FixedComp
 }
 
 #endif
- 

--- a/System/flukaTally/userBin.cxx
+++ b/System/flukaTally/userBin.cxx
@@ -61,7 +61,8 @@ userBin::userBin(const std::string& tallyName,
 		   const int ID,const int outID) :
   flukaTally(tallyName,ID,outID),
   meshType(10),particle("208"),
-  Pts({0,0,0})
+  Pts({0,0,0}),
+  hasLinkTransform(false)
   /*!
     Constructor
     \param outID :: Identity number of tally [fortranOut]
@@ -72,7 +73,10 @@ userBin::userBin(const userBin& A) :
   flukaTally(A),
   meshType(A.meshType),particle(A.particle),
   Pts(A.Pts),minCoord(A.minCoord),
-  maxCoord(A.maxCoord)
+  maxCoord(A.maxCoord),
+  hasLinkTransform(A.hasLinkTransform),
+  linkOrigin(A.linkOrigin),
+  linkX(A.linkX),linkY(A.linkY),linkZ(A.linkZ)
   /*!
     Copy constructor
     \param A :: userBin to copy
@@ -95,6 +99,11 @@ userBin::operator=(const userBin& A)
       Pts=A.Pts;
       minCoord=A.minCoord;
       maxCoord=A.maxCoord;
+      hasLinkTransform=A.hasLinkTransform;
+      linkOrigin=A.linkOrigin;
+      linkX=A.linkX;
+      linkY=A.linkY;
+      linkZ=A.linkZ;
     }
   return *this;
 }
@@ -142,6 +151,29 @@ userBin::setDoseType(const std::string& P,
   return;
 }
 
+
+void
+userBin::setLinkTransform(const Geometry::Vec3D& origin,
+			  const Geometry::Vec3D& X,
+			  const Geometry::Vec3D& Y,
+			  const Geometry::Vec3D& Z)
+  /*!
+    Store the link point world position and orientation axes so that
+    write() can emit ROT-DEFIni / ROTPRBIN cards aligning the USRBIN
+    mesh with the link point's local frame.
+    \param origin :: Link point world position
+    \param X :: Link point X axis (world frame)
+    \param Y :: Link point Y axis (world frame)
+    \param Z :: Link point Z axis (world frame)
+  */
+{
+  hasLinkTransform = true;
+  linkOrigin = origin;
+  linkX = X;
+  linkY = Y;
+  linkZ = Z;
+  return;
+}
 
 void
 userBin::setIndex(const std::array<size_t,3>& IDX)
@@ -211,26 +243,129 @@ userBin::writeAuxScore(std::ostream& OX) const
 void
 userBin::write(std::ostream& OX) const
   /*!
-    Write out the mesh tally into the tally region
+    Write out the mesh tally into the tally region.
+    When a link transform has been set via setLinkTransform(), three
+    ROT-DEFIni cards and one ROTPRBIN card are emitted so that the
+    USRBIN mesh follows the link point under geometry rotations.
+    The USRBIN extents are expressed in the link point's local frame.
     \param OX :: Output stream
    */
 {
   std::ostringstream cx;
-
   const int outputUnit(getOutUnit());
-  cx<<"USRBIN "<<meshType<<" "<<particle<<" "
-    <<outputUnit<<" "<<maxCoord;
-  cx<<" "<<keyName;
-  StrFunc::writeFLUKA(cx.str(),OX);
 
-  cx.str("");
-  cx<<"USRBIN "<<minCoord<<" ";
+  if (hasLinkTransform)
+    {
+      // --- ROT-DEFIni: encode the transformation world → local frame ---
+      //
+      // The link point's rotation matrix R = [linkX | linkY | linkZ]
+      // (columns are the local axes expressed in world coordinates).
+      // We need the inverse: R^T = Rx(-gamma) * Ry(-beta) * Rz(-alpha),
+      // using ZYX Euler angles extracted from R:
+      //   R = Rz(alpha) * Ry(beta) * Rx(gamma)
+      //
+      // FLUKA ROT-DEFIni with Theta=0:
+      //   j=3, Phi=alpha  →  Rz(-alpha)
+      //   j=2, Phi=beta   →  Ry(-beta)
+      //   j=1, Phi=gamma  →  Rx(-gamma)
+      // Three cards with the same SDUM are composed left-to-right
+      // (later card is outermost), giving: Rx(-gamma)*Ry(-beta)*Rz(-alpha)=R^T.
+      // The translation (-linkOrigin) is carried by the first card.
 
-  for(size_t i=0;i<3;i++)
-    cx<<Pts[i]<<" ";
-  cx<<"  & ";
-  StrFunc::writeFLUKA(cx.str(),OX);
-  writeAuxScore(OX);
+      const double toDeg = 180.0 / M_PI;
+      const double cosB = std::sqrt(linkX[0]*linkX[0] + linkX[1]*linkX[1]);
+
+      double alpha, beta, gamma;
+      beta = std::atan2(-linkX[2], cosB) * toDeg;
+
+      if (cosB > 1e-10)
+        {
+          alpha = std::atan2(linkX[1], linkX[0]) * toDeg;
+          gamma = std::atan2(linkY[2], linkZ[2]) * toDeg;
+        }
+      else
+        {
+          // Gimbal lock: beta = ±90°.  Set alpha = 0, derive gamma from Y.
+          alpha = 0.0;
+          if (linkX[2] < 0)   // beta = +90°
+            gamma = std::atan2(linkY[0], linkY[1]) * toDeg;
+          else                // beta = -90°
+            gamma = std::atan2(-linkY[0], linkY[1]) * toDeg;
+        }
+
+      // Transformation index: use |outputUnit| as the ROT-DEFIni index i.
+      const int rotIdx = std::abs(outputUnit);
+      const std::string rotName = "R" + std::to_string(rotIdx);
+
+      // Card 1: j=3 (z-rotation by alpha), carry the translation -linkOrigin.
+      cx << "ROT-DEFI "
+         << (3 + rotIdx * 1000) << " "
+         << 0.0 << " " << alpha << " "
+         << (-linkOrigin) << " "
+         << rotName;
+      StrFunc::writeFLUKA(cx.str(), OX);
+
+      // Card 2: j=2 (y-rotation by beta), no translation.
+      cx.str("");
+      cx << "ROT-DEFI "
+         << (2 + rotIdx * 1000) << " "
+         << 0.0 << " " << beta << " "
+         << 0.0 << " " << 0.0 << " " << 0.0 << " "
+         << rotName;
+      StrFunc::writeFLUKA(cx.str(), OX);
+
+      // Card 3: j=1 (x-rotation by gamma), no translation.
+      cx.str("");
+      cx << "ROT-DEFI "
+         << (1 + rotIdx * 1000) << " "
+         << 0.0 << " " << gamma << " "
+         << 0.0 << " " << 0.0 << " " << 0.0 << " "
+         << rotName;
+      StrFunc::writeFLUKA(cx.str(), OX);
+
+      // --- USRBIN: extents in the link point's local frame ---
+      const Geometry::Vec3D localMin = minCoord - linkOrigin;
+      const Geometry::Vec3D localMax = maxCoord - linkOrigin;
+
+      cx.str("");
+      cx << "USRBIN " << meshType << " " << particle << " "
+         << outputUnit << " " << localMax << " " << keyName;
+      StrFunc::writeFLUKA(cx.str(), OX);
+
+      cx.str("");
+      cx << "USRBIN " << localMin << " ";
+      for (size_t i=0; i<3; i++)
+        cx << Pts[i] << " ";
+      cx << "  & ";
+      StrFunc::writeFLUKA(cx.str(), OX);
+
+      writeAuxScore(OX);
+
+      // --- ROTPRBIN: associate the ROT-DEFIni with this USRBIN ---
+      cx.str("");
+      cx << "ROTPRBIN "
+         << 0.0 << " "
+         << rotIdx << " "
+         << 0.0 << " "
+         << keyName << " "
+         << keyName << " "
+         << 0.0;
+      StrFunc::writeFLUKA(cx.str(), OX);
+    }
+  else
+    {
+      cx << "USRBIN " << meshType << " " << particle << " "
+         << outputUnit << " " << maxCoord << " " << keyName;
+      StrFunc::writeFLUKA(cx.str(), OX);
+
+      cx.str("");
+      cx << "USRBIN " << minCoord << " ";
+      for (size_t i=0; i<3; i++)
+        cx << Pts[i] << " ";
+      cx << "  & ";
+      StrFunc::writeFLUKA(cx.str(), OX);
+      writeAuxScore(OX);
+    }
 
   flukaTally::write(OX);
   return;

--- a/System/flukaTally/userBin.cxx
+++ b/System/flukaTally/userBin.cxx
@@ -3,7 +3,7 @@
 
  * File:   flukaTally/userBin.cxx
  *
- * Copyright (c) 2004-2021 by Stuart Ansell
+ * Copyright (c) 2004-2026 by Stuart Ansell and Konstantin Batkov
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -256,83 +256,6 @@ userBin::write(std::ostream& OX) const
 
   if (hasLinkTransform)
     {
-      // --- ROT-DEFIni: encode the transformation world → local frame ---
-      //
-      // The link point's rotation matrix R = [linkX | linkY | linkZ]
-      // (columns are the local axes expressed in world coordinates).
-      // We need the inverse: R^T = Rx(-gamma) * Ry(-beta) * Rz(-alpha),
-      // using ZYX Euler angles extracted from R:
-      //   R = Rz(alpha) * Ry(beta) * Rx(gamma)
-      //
-      // FLUKA ROT-DEFIni with Theta=0:
-      //   j=3, Phi=alpha  →  Rz(-alpha)
-      //   j=2, Phi=beta   →  Ry(-beta)
-      //   j=1, Phi=gamma  →  Rx(-gamma)
-      // Three cards with the same SDUM are composed left-to-right
-      // (later card is outermost), giving: Rx(-gamma)*Ry(-beta)*Rz(-alpha)=R^T.
-      // The translation (-linkOrigin) is carried by the first card.
-
-      const double toDeg = 180.0 / M_PI;
-      const double cosB = std::sqrt(linkX[0]*linkX[0] + linkX[1]*linkX[1]);
-
-      double alpha, beta, gamma;
-      beta = std::atan2(-linkX[2], cosB) * toDeg;
-
-      if (cosB > 1e-10)
-        {
-          alpha = std::atan2(linkX[1], linkX[0]) * toDeg;
-          gamma = std::atan2(linkY[2], linkZ[2]) * toDeg;
-        }
-      else
-        {
-          // Gimbal lock: beta = ±90°.  Set alpha = 0, derive gamma from Y.
-          alpha = 0.0;
-          if (linkX[2] < 0)   // beta = +90°
-            gamma = std::atan2(linkY[0], linkY[1]) * toDeg;
-          else                // beta = -90°
-            gamma = std::atan2(-linkY[0], linkY[1]) * toDeg;
-        }
-
-      // Wrap all angles to [0°, 360°) for FLUKA conventions
-      if (alpha < 0.0) alpha += 360.0;
-      if (beta  < 0.0) beta  += 360.0;
-      if (gamma < 0.0) gamma += 360.0;
-
-      // Transformation index: use |outputUnit| as the ROT-DEFIni index i.
-      const int rotIdx = std::abs(outputUnit);
-      const std::string rotName = "R" + std::to_string(rotIdx);
-
-      // Card 1: j=3 (z-rotation by alpha), carry the translation -linkOrigin.
-      cx << "ROT-DEFI "
-         << (3 + rotIdx * 1000) << " "
-         << 0.0 << " " << alpha << " "
-         << (-linkOrigin) << " "
-         << rotName;
-      StrFunc::writeFLUKA(cx.str(), OX);
-
-      // Card 2: j=2 (y-rotation by beta), no translation.
-      if (std::abs(beta)>Geometry::zeroTol) { // TODO: also check translation
-	cx.str("");
-	cx << "ROT-DEFI "
-	   << (2 + rotIdx * 1000) << " "
-	   << 0.0 << " " << beta << " "
-	   << 0.0 << " " << 0.0 << " " << 0.0 << " "
-	   << rotName;
-	StrFunc::writeFLUKA(cx.str(), OX);
-      }
-
-      // Card 3: j=1 (x-rotation by gamma), no translation.
-      if (std::abs(gamma)>Geometry::zeroTol) { // TODO: also check translation
-	cx.str("");
-	cx << "ROT-DEFI "
-	   << (1 + rotIdx * 1000) << " "
-	   << 0.0 << " " << gamma << " "
-	   << 0.0 << " " << 0.0 << " " << 0.0 << " "
-	   << rotName;
-	StrFunc::writeFLUKA(cx.str(), OX);
-      }
-
-      // --- USRBIN: extents in the link point's local frame ---
       const Geometry::Vec3D localMin = minCoord - linkOrigin;
       const Geometry::Vec3D localMax = maxCoord - linkOrigin;
 

--- a/System/flukaTally/userBin.cxx
+++ b/System/flukaTally/userBin.cxx
@@ -378,6 +378,20 @@ userBin::write(std::ostream& OX) const
                     }
                 }
 
+          // Permute bin counts from local-frame order to world-frame order.
+          // R = [linkX|linkY|linkZ]: for world axis i the nonzero entry in
+          // row i identifies which local axis j (0=X,1=Y,2=Z) maps there.
+          std::array<size_t, 3> worldPts;
+          for (int i = 0; i < 3; i++)
+            {
+              if (std::abs(linkX[i]) > 0.5)
+                worldPts[i] = Pts[0];
+              else if (std::abs(linkY[i]) > 0.5)
+                worldPts[i] = Pts[1];
+              else
+                worldPts[i] = Pts[2];
+            }
+
           cx << "USRBIN " << meshType << " " << particle << " "
              << outputUnit << " " << wMax << " " << keyName;
           StrFunc::writeFLUKA(cx.str(), OX);
@@ -385,7 +399,7 @@ userBin::write(std::ostream& OX) const
           cx.str("");
           cx << "USRBIN " << wMin << " ";
           for (size_t i = 0; i < 3; i++)
-            cx << Pts[i] << " ";
+            cx << worldPts[i] << " ";
           cx << "  & ";
           StrFunc::writeFLUKA(cx.str(), OX);
 

--- a/System/flukaTally/userBin.cxx
+++ b/System/flukaTally/userBin.cxx
@@ -311,22 +311,26 @@ userBin::write(std::ostream& OX) const
       StrFunc::writeFLUKA(cx.str(), OX);
 
       // Card 2: j=2 (y-rotation by beta), no translation.
-      cx.str("");
-      cx << "ROT-DEFI "
-         << (2 + rotIdx * 1000) << " "
-         << 0.0 << " " << beta << " "
-         << 0.0 << " " << 0.0 << " " << 0.0 << " "
-         << rotName;
-      StrFunc::writeFLUKA(cx.str(), OX);
+      if (std::abs(beta)>Geometry::zeroTol) { // TODO: also check translation
+	cx.str("");
+	cx << "ROT-DEFI "
+	   << (2 + rotIdx * 1000) << " "
+	   << 0.0 << " " << beta << " "
+	   << 0.0 << " " << 0.0 << " " << 0.0 << " "
+	   << rotName;
+	StrFunc::writeFLUKA(cx.str(), OX);
+      }
 
       // Card 3: j=1 (x-rotation by gamma), no translation.
-      cx.str("");
-      cx << "ROT-DEFI "
-         << (1 + rotIdx * 1000) << " "
-         << 0.0 << " " << gamma << " "
-         << 0.0 << " " << 0.0 << " " << 0.0 << " "
-         << rotName;
-      StrFunc::writeFLUKA(cx.str(), OX);
+      if (std::abs(gamma)>Geometry::zeroTol) { // TODO: also check translation
+	cx.str("");
+	cx << "ROT-DEFI "
+	   << (1 + rotIdx * 1000) << " "
+	   << 0.0 << " " << gamma << " "
+	   << 0.0 << " " << 0.0 << " " << 0.0 << " "
+	   << rotName;
+	StrFunc::writeFLUKA(cx.str(), OX);
+      }
 
       // --- USRBIN: extents in the link point's local frame ---
       const Geometry::Vec3D localMin = minCoord - linkOrigin;
@@ -348,13 +352,7 @@ userBin::write(std::ostream& OX) const
 
       // --- ROTPRBIN: associate the ROT-DEFIni with this USRBIN ---
       cx.str("");
-      cx << "ROTPRBIN "
-         << 0.0 << " "
-         << rotIdx << " "
-         << 0.0 << " "
-         << keyName << " "
-         << keyName << " "
-         << 0.0;
+      cx << "ROTPRBIN - " << rotName << " - " << keyName << " - - ";
       StrFunc::writeFLUKA(cx.str(), OX);
     }
   else

--- a/System/flukaTally/userBin.cxx
+++ b/System/flukaTally/userBin.cxx
@@ -293,6 +293,11 @@ userBin::write(std::ostream& OX) const
             gamma = std::atan2(-linkY[0], linkY[1]) * toDeg;
         }
 
+      // Wrap all angles to [0°, 360°) for FLUKA conventions
+      if (alpha < 0.0) alpha += 360.0;
+      if (beta  < 0.0) beta  += 360.0;
+      if (gamma < 0.0) gamma += 360.0;
+
       // Transformation index: use |outputUnit| as the ROT-DEFIni index i.
       const int rotIdx = std::abs(outputUnit);
       const std::string rotName = "R" + std::to_string(rotIdx);

--- a/System/flukaTally/userBin.cxx
+++ b/System/flukaTally/userBin.cxx
@@ -336,24 +336,144 @@ userBin::write(std::ostream& OX) const
       const Geometry::Vec3D localMin = minCoord - linkOrigin;
       const Geometry::Vec3D localMax = maxCoord - linkOrigin;
 
-      cx.str("");
-      cx << "USRBIN " << meshType << " " << particle << " "
-         << outputUnit << " " << localMax << " " << keyName;
-      StrFunc::writeFLUKA(cx.str(), OX);
+      // Check if every component of each axis is 0 or ±1 (rotation is a
+      // multiple of 90°, so the mesh stays axis-aligned in world frame).
+      auto isAxComponent = [](double c) -> bool {
+        return std::abs(c) < Geometry::zeroTol ||
+               std::abs(std::abs(c) - 1.0) < Geometry::zeroTol;
+      };
+      auto isAxisAligned = [&](const Geometry::Vec3D& v) -> bool {
+        return isAxComponent(v[0]) && isAxComponent(v[1]) && isAxComponent(v[2]);
+      };
 
-      cx.str("");
-      cx << "USRBIN " << localMin << " ";
-      for (size_t i=0; i<3; i++)
-        cx << Pts[i] << " ";
-      cx << "  & ";
-      StrFunc::writeFLUKA(cx.str(), OX);
+      if (isAxisAligned(linkX) && isAxisAligned(linkY) && isAxisAligned(linkZ))
+        {
+          // Rotation is axis-aligned: map the 8 local corners to world frame
+          // and take the component-wise min/max.  No ROT-DEFIni/ROTPRBIN needed.
+          Geometry::Vec3D wMin(0,0,0), wMax(0,0,0);
+          bool first = true;
+          for (int sx = 0; sx <= 1; sx++)
+            for (int sy = 0; sy <= 1; sy++)
+              for (int sz = 0; sz <= 1; sz++)
+                {
+                  const double lx = sx ? localMax[0] : localMin[0];
+                  const double ly = sy ? localMax[1] : localMin[1];
+                  const double lz = sz ? localMax[2] : localMin[2];
+                  Geometry::Vec3D wc(
+                    linkOrigin[0] + lx*linkX[0] + ly*linkY[0] + lz*linkZ[0],
+                    linkOrigin[1] + lx*linkX[1] + ly*linkY[1] + lz*linkZ[1],
+                    linkOrigin[2] + lx*linkX[2] + ly*linkY[2] + lz*linkZ[2]);
+                  if (first)
+                    {
+                      wMin = wMax = wc;
+                      first = false;
+                    }
+                  else
+                    {
+                      for (int i = 0; i < 3; i++)
+                        {
+                          if (wc[i] < wMin[i]) wMin[i] = wc[i];
+                          if (wc[i] > wMax[i]) wMax[i] = wc[i];
+                        }
+                    }
+                }
 
-      writeAuxScore(OX);
+          cx << "USRBIN " << meshType << " " << particle << " "
+             << outputUnit << " " << wMax << " " << keyName;
+          StrFunc::writeFLUKA(cx.str(), OX);
 
-      // --- ROTPRBIN: associate the ROT-DEFIni with this USRBIN ---
-      cx.str("");
-      cx << "ROTPRBIN - " << rotName << " - " << keyName << " - - ";
-      StrFunc::writeFLUKA(cx.str(), OX);
+          cx.str("");
+          cx << "USRBIN " << wMin << " ";
+          for (size_t i = 0; i < 3; i++)
+            cx << Pts[i] << " ";
+          cx << "  & ";
+          StrFunc::writeFLUKA(cx.str(), OX);
+
+          writeAuxScore(OX);
+        }
+      else
+        {
+          // Non-axis-aligned rotation: emit ROT-DEFIni + ROTPRBIN cards.
+          //
+          // R = [linkX | linkY | linkZ] (columns = local axes in world coords)
+          // R = Rz(alpha)*Ry(beta)*Rx(gamma)  →  R^T = Rx(-gamma)*Ry(-beta)*Rz(-alpha)
+          //
+          // FLUKA ROT-DEFIni Theta=0: j=3→Rz(-Phi), j=2→Ry(-Phi), j=1→Rx(-Phi).
+          // Cards with the same SDUM compose left-to-right (later = outermost).
+
+          const double toDeg = 180.0 / M_PI;
+          const double cosB = std::sqrt(linkX[0]*linkX[0] + linkX[1]*linkX[1]);
+
+          double alpha, beta, gamma;
+          beta = std::atan2(-linkX[2], cosB) * toDeg;
+
+          if (cosB > 1e-10)
+            {
+              alpha = std::atan2(linkX[1], linkX[0]) * toDeg;
+              gamma = std::atan2(linkY[2], linkZ[2]) * toDeg;
+            }
+          else
+            {
+              alpha = 0.0;
+              if (linkX[2] < 0)
+                gamma = std::atan2(linkY[0], linkY[1]) * toDeg;
+              else
+                gamma = std::atan2(-linkY[0], linkY[1]) * toDeg;
+            }
+          if (alpha < 0.0) alpha += 360.0;
+          if (beta  < 0.0) beta  += 360.0;
+          if (gamma < 0.0) gamma += 360.0;
+
+          const int rotIdx = std::abs(outputUnit);
+          const std::string rotName = "R" + std::to_string(rotIdx);
+
+          cx << "ROT-DEFI "
+             << (3 + rotIdx * 1000) << " "
+             << 0.0 << " " << alpha << " "
+             << (-linkOrigin) << " "
+             << rotName;
+          StrFunc::writeFLUKA(cx.str(), OX);
+
+          if (std::abs(beta) > Geometry::zeroTol)
+            {
+              cx.str("");
+              cx << "ROT-DEFI "
+                 << (2 + rotIdx * 1000) << " "
+                 << 0.0 << " " << beta << " "
+                 << 0.0 << " " << 0.0 << " " << 0.0 << " "
+                 << rotName;
+              StrFunc::writeFLUKA(cx.str(), OX);
+            }
+
+          if (std::abs(gamma) > Geometry::zeroTol)
+            {
+              cx.str("");
+              cx << "ROT-DEFI "
+                 << (1 + rotIdx * 1000) << " "
+                 << 0.0 << " " << gamma << " "
+                 << 0.0 << " " << 0.0 << " " << 0.0 << " "
+                 << rotName;
+              StrFunc::writeFLUKA(cx.str(), OX);
+            }
+
+          cx.str("");
+          cx << "USRBIN " << meshType << " " << particle << " "
+             << outputUnit << " " << localMax << " " << keyName;
+          StrFunc::writeFLUKA(cx.str(), OX);
+
+          cx.str("");
+          cx << "USRBIN " << localMin << " ";
+          for (size_t i = 0; i < 3; i++)
+            cx << Pts[i] << " ";
+          cx << "  & ";
+          StrFunc::writeFLUKA(cx.str(), OX);
+
+          writeAuxScore(OX);
+
+          cx.str("");
+          cx << "ROTPRBIN - " << rotName << " - " << keyName << " - - ";
+          StrFunc::writeFLUKA(cx.str(), OX);
+        }
     }
   else
     {

--- a/System/flukaTally/userBinConstruct.cxx
+++ b/System/flukaTally/userBinConstruct.cxx
@@ -92,6 +92,48 @@ userBinConstruct::createTally(SimFLUKA& System,
   return;
 }
 
+void
+userBinConstruct::createTally(SimFLUKA& System,
+			      const std::string& name,
+			      const std::string& PType,
+			      const int fortranTape,
+			      const Geometry::Vec3D& APt,
+			      const Geometry::Vec3D& BPt,
+			      const std::array<size_t,3>& MPts,
+			      const Geometry::Vec3D& linkOrigin,
+			      const Geometry::Vec3D& linkX,
+			      const Geometry::Vec3D& linkY,
+			      const Geometry::Vec3D& linkZ)
+  /*!
+    Create a mesh tally with a link-point transform so that
+    ROT-DEFIni / ROTPRBIN cards are written to align the USRBIN mesh
+    with the link point's local frame.
+    \param System :: SimFLUKA to add tallies
+    \param name :: tally name
+    \param PType :: processed particle type
+    \param fortranTape :: output stream
+    \param APt :: Lower point (world frame, origin at link point)
+    \param BPt :: Upper point (world frame, origin at link point)
+    \param MPts :: Number of bins
+    \param linkOrigin :: Link point world position
+    \param linkX :: Link point X axis
+    \param linkY :: Link point Y axis
+    \param linkZ :: Link point Z axis
+  */
+{
+  ELog::RegMethod RegA("userBinConstruct","createTally(linkTransform)");
+
+  userBin UB(fortranTape,fortranTape);
+  UB.setKeyName(name);
+  UB.setParticle(PType);
+  UB.setCoordinates(APt,BPt);
+  UB.setIndex(MPts);
+  UB.setLinkTransform(linkOrigin,linkX,linkY,linkZ);
+  System.addTally(UB);
+
+  return;
+}
+
 std::string
 userBinConstruct::convertTallyType(const std::string& TType)
   /*!
@@ -148,12 +190,21 @@ userBinConstruct::processMesh(SimFLUKA& System,
   std::array<size_t,3> Nxyz;
 
   if (PType=="object")
-    mainSystem::meshConstruct::getObjectMesh
-      (System,IParam,"tally",Index,4,APt,BPt,Nxyz);
-  else if (PType=="free")
-    mainSystem::meshConstruct::getFreeMesh(IParam,"tally",Index,4,APt,BPt,Nxyz);
-
-  userBinConstruct::createTally(System,tallyName,tallyParticle,-nextId,APt,BPt,Nxyz);
+    {
+      Geometry::Vec3D linkOrigin, linkX, linkY, linkZ;
+      mainSystem::meshConstruct::getObjectMesh
+        (System,IParam,"tally",Index,4,APt,BPt,Nxyz,
+	 linkOrigin,linkX,linkY,linkZ);
+      userBinConstruct::createTally(System,tallyName,tallyParticle,-nextId,
+				    APt,BPt,Nxyz,
+				    linkOrigin,linkX,linkY,linkZ);
+    }
+  else
+    {
+      if (PType=="free")
+        mainSystem::meshConstruct::getFreeMesh(IParam,"tally",Index,4,APt,BPt,Nxyz);
+      userBinConstruct::createTally(System,tallyName,tallyParticle,-nextId,APt,BPt,Nxyz);
+    }
 
   return;
 }

--- a/System/flukaTallyInc/userBin.h
+++ b/System/flukaTallyInc/userBin.h
@@ -38,11 +38,17 @@ class userBin : public flukaTally
 
   int meshType;                     ///< type / 10 / 0 for mesh
   std::string particle;             ///< particle/type
-    
+
   std::array<size_t,3> Pts;      ///< N-Points
-  Geometry::Vec3D minCoord;      ///< Min coordinate
-  Geometry::Vec3D maxCoord;      ///< Max coordinate
-  
+  Geometry::Vec3D minCoord;      ///< Min coordinate (world frame)
+  Geometry::Vec3D maxCoord;      ///< Max coordinate (world frame)
+
+  bool hasLinkTransform;         ///< Whether to write ROT-DEFIni/ROTPRBIN
+  Geometry::Vec3D linkOrigin;    ///< Link point world position
+  Geometry::Vec3D linkX;         ///< Link point X axis (world frame)
+  Geometry::Vec3D linkY;         ///< Link point Y axis (world frame)
+  Geometry::Vec3D linkZ;         ///< Link point Z axis (world frame)
+
   void writeMesh(std::ostream&) const;
   
  public:
@@ -62,6 +68,10 @@ class userBin : public flukaTally
   
   void setParticle(const std::string&);
   void setDoseType(const std::string&,const std::string&) override;
+  void setLinkTransform(const Geometry::Vec3D&,
+			const Geometry::Vec3D&,
+			const Geometry::Vec3D&,
+			const Geometry::Vec3D&);
  
   void setIndex(const std::array<size_t,3>&);
   void setCoordinates(const Geometry::Vec3D&,const Geometry::Vec3D&);

--- a/System/flukaTallyInc/userBinConstruct.h
+++ b/System/flukaTallyInc/userBinConstruct.h
@@ -59,6 +59,17 @@ class userBinConstruct
 			  const Geometry::Vec3D&,const Geometry::Vec3D&,
 			  const std::array<size_t,3>&);
 
+  static void createTally(SimFLUKA&,
+			  const std::string&,
+			  const std::string&,
+			  const int,
+			  const Geometry::Vec3D&,const Geometry::Vec3D&,
+			  const std::array<size_t,3>&,
+			  const Geometry::Vec3D&,
+			  const Geometry::Vec3D&,
+			  const Geometry::Vec3D&,
+			  const Geometry::Vec3D&);
+
 
   static std::string convertTallyType(const std::string&);
 

--- a/System/generalProcess/Process.cxx
+++ b/System/generalProcess/Process.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   generalProcess/Process.cxx
  *
  * Copyright (c) 2004-2024 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <iostream>
@@ -107,7 +107,7 @@ setWImp(Simulation& System,const mainSystem::inputParam& IParam)
 	  impValue=IParam.getValueError<double>
 	    ("wIMP",setIndex,1," IMP value for wIMP");
 	}
-      
+
       const std::set<int> cells=
 	ModelSupport::getActiveCell(System,cellName);
       for(const int CN : cells)
@@ -115,7 +115,7 @@ setWImp(Simulation& System,const mainSystem::inputParam& IParam)
     }
   return;
 }
-  
+
 std::set<int>
 getActiveMaterial(const Simulation& System,
 		  std::string material)
@@ -129,18 +129,18 @@ getActiveMaterial(const Simulation& System,
 
   const ModelSupport::DBMaterial& DB=
     ModelSupport::DBMaterial::Instance();
-  
+
   std::set<int> activeMat=System.getActiveMaterial();
   if (material=="All" || material=="all")
     return activeMat;
-  
+
   bool negKey(0);
   if (material.size()>1 && material.back()=='-')
     {
       negKey=1;
       material.pop_back();
     }
-  
+
   if (!DB.hasKey(material))
     throw ColErr::InContainerError<std::string>
       (material,"Material not in material database");
@@ -154,7 +154,7 @@ getActiveMaterial(const Simulation& System,
   if (activeMat.find(matID)==activeMat.end())
     throw ColErr::InContainerError<std::string>
       (material,"Not present in model");
-  
+
   std::set<int> activeOut;
   activeOut.insert(matID);
   return activeOut;
@@ -165,9 +165,9 @@ getActiveCell(const objectGroups& OGrp,
 	      const std::string& cell)
   /*!
     Given a cell find the active cells
-    \param OGrp :: Active group						
+    \param OGrp :: Active group
     \param cell : cell name to use
-    \return set of active cell numbers 
+    \return set of active cell numbers
   */
 {
   ELog::RegMethod RegA("Process[F]","getActiveCell");
@@ -177,7 +177,7 @@ getActiveCell(const objectGroups& OGrp,
   activeCell.erase(1);
   return activeCell;
 }
-  
+
 void
 setDefRotation(const objectGroups& OGrp,
 	       const mainSystem::inputParam& IParam)
@@ -196,7 +196,7 @@ setDefRotation(const objectGroups& OGrp,
       MR.addRotation(Geometry::Vec3D(0,1,0),
 		     Geometry::Vec3D(0,0,0),
 		     90.0);
-      //Move XY to -X-Y 
+      //Move XY to -X-Y
       MR.addRotation(Geometry::Vec3D(0,0,1),
 		     Geometry::Vec3D(0,0,0),
 		     -90.0);
@@ -238,7 +238,7 @@ procAngle(const objectGroups& OGrp,
   */
 {
   ELog::RegMethod RegA("Process[F]","procAngle");
-  
+
   masterRotate& MR = masterRotate::Instance();
 
   const std::string AItem=
@@ -279,7 +279,7 @@ procAngle(const objectGroups& OGrp,
         IParam.getDefValue<std::string>("2","angle",index,2);
 
       const long int sideIndex=GIPtr->getSideIndex(CItem);
-          
+
       Geometry::Vec3D LP=GIPtr->getLinkPt(sideIndex);
       LP=LP.cutComponent(Geometry::Vec3D(0,0,1));
       LP.makeUnit();
@@ -297,9 +297,9 @@ procAngle(const objectGroups& OGrp,
         OGrp.getObjectThrow<attachSystem::FixedComp>(BItem,"FixedComp");
       const std::string CItem=
         IParam.getDefValue<std::string>("2","angle",index,2);
-      
+
       const long int sideIndex=GIPtr->getSideIndex(CItem);
-      
+
       Geometry::Vec3D XRotAxis,YRotAxis,ZRotAxis;
       GIPtr->calcLinkAxis(sideIndex,XRotAxis,YRotAxis,ZRotAxis);
 
@@ -307,7 +307,7 @@ procAngle(const objectGroups& OGrp,
 	{
 	  const Geometry::Quaternion QR=Geometry::Quaternion::calcQVRot
 	    (Geometry::Vec3D(0,1,0),YRotAxis,ZRotAxis);
-	  
+
 	  MR.addRotation(QR.getAxis(),Geometry::Vec3D(0,0,0),
 			 -180.0*QR.getTheta()/M_PI);
 	}
@@ -315,11 +315,10 @@ procAngle(const objectGroups& OGrp,
 	{
 	  const Geometry::Quaternion QR=Geometry::Quaternion::calcQVRot
 	    (Geometry::Vec3D(0,0,1),YRotAxis,ZRotAxis);
-	  ELog::EM<<"Axis == "<<XRotAxis<<ELog::endDiag;
-	  ELog::EM<<"Axis == "<<YRotAxis<<ELog::endDiag;
-	  ELog::EM<<"Axis == "<<ZRotAxis<<ELog::endDiag;
-
-	  ELog::EM<<"Axis == "<<QR.getAxis()<<ELog::endDiag;
+	  // ELog::EM<<"Axis == "<<XRotAxis<<ELog::endDiag;
+	  // ELog::EM<<"Axis == "<<YRotAxis<<ELog::endDiag;
+	  // ELog::EM<<"Axis == "<<ZRotAxis<<ELog::endDiag;
+	  // ELog::EM<<"Axis == "<<QR.getAxis()<<ELog::endDiag;
 	  MR.addRotation(QR.getAxis(),Geometry::Vec3D(0,0,0),
 			 -180.0*QR.getTheta()/M_PI);
 	}
@@ -327,7 +326,7 @@ procAngle(const objectGroups& OGrp,
 	{
 	  const Geometry::Quaternion QR=Geometry::Quaternion::calcQVRot
 	    (Geometry::Vec3D(1,0,0),YRotAxis,ZRotAxis);
-	  
+
 	  MR.addRotation(QR.getAxis(),Geometry::Vec3D(0,0,0),
 			 -180.0*QR.getTheta()/M_PI);
 	}
@@ -339,12 +338,12 @@ procAngle(const objectGroups& OGrp,
       const attachSystem::FixedComp* GIPtr=
         OGrp.getObjectThrow<attachSystem::FixedComp>(BItem,"FixedComp");
       const std::string CItem=
-        IParam.getDefValue<std::string>("2","angle",index,2);      
+        IParam.getDefValue<std::string>("2","angle",index,2);
 
       Geometry::Vec3D YAxis=GIPtr->getLinkAxis(CItem);
       YAxis=YAxis.cutComponent(Geometry::Vec3D(0,0,1)).unit();  // Y' in the plane of Z=0
       const double rAngle=YAxis.dotProd(Geometry::Vec3D(0,1,0));
-      
+
       MR.addRotation(Geometry::Vec3D(0,0,1),Geometry::Vec3D(0,0,0),
 		     -180.0*rAngle/M_PI);
     }
@@ -364,7 +363,7 @@ procAngle(const objectGroups& OGrp,
       const double rotAngle=
         IParam.getValue<double>("angle",index,itemIndex);
       MR.addRotation(rotAxis,Geometry::Vec3D(0,0,0),
-                     -rotAngle);		  
+                     -rotAngle);
     }
   else if (AItem=="help" || AItem=="Help")
     {
@@ -381,7 +380,7 @@ procAngle(const objectGroups& OGrp,
     }
   else
     throw ColErr::InContainerError<std::string>(AItem,"angle input error");
-      
+
   return;
 }
 
@@ -399,7 +398,7 @@ procOffset(const objectGroups& OGrp,
   */
 {
   ELog::RegMethod RegA("Process[F]","procOffset");
-  masterRotate& MR = masterRotate::Instance();  
+  masterRotate& MR = masterRotate::Instance();
 
   const std::string AItem=
     IParam.getValue<std::string>(keyID,index);
@@ -429,7 +428,7 @@ procOffset(const objectGroups& OGrp,
 
   return;
 }
-  
-  
+
+
 
 } // NAMESPACE ModelSupport

--- a/System/generalProcess/meshConstruct.cxx
+++ b/System/generalProcess/meshConstruct.cxx
@@ -84,42 +84,10 @@ calcXYZ(const objectGroups& OGrp,
   attachSystem::FixedUnit A("tmpComp",0);
   A.createUnitVector(*FC,sideIndex);
 
-  //
-  // Construct the 8 corners of the cube:
-  // then calculate the maximum in all directions
-  //
-  std::vector<Geometry::Vec3D> Cube(8);
-  Cube[0]=APos;
-  Cube[7]=BPos;
-  for(size_t i=0;i<3;i++)
-    {
-      Cube[i+1]=APos;
-      Cube[i+1][i]=BPos[i];
-    }
-  for(size_t i=0;i<3;i++)
-    {
-      Cube[i+5]=BPos;
-      Cube[i+5][i]=APos[i];
-    }
-
-  Geometry::Vec3D Pt=A.getX()*Cube[0][0]+
-    A.getY()*Cube[0][1]+A.getZ()*Cube[0][2];
-
-  Geometry::Vec3D PtMax(Pt);
-  Geometry::Vec3D PtMin(Pt);
-  for(size_t i=1;i<8;i++)
-    {
-      Pt=A.getX()*Cube[i][0]+A.getY()*Cube[i][1]+A.getZ()*Cube[i][2];
-      for(size_t j=0;j<3;j++)
-	{
-	  if (Pt[j]>PtMax[j]) PtMax[j]=Pt[j];
-	  if (Pt[j]<PtMin[j]) PtMin[j]=Pt[j];
-	}
-    }
-
-  ELog::EM<<"Center == "<<A.getCentre()<<ELog::endDiag;
-  APos=PtMin+A.getCentre();
-  BPos=PtMax+A.getCentre();
+  // APos/BPos are offsets from the mesh origin (0,0,0).
+  // Translate so that the mesh origin coincides with the link point.
+  APos += A.getCentre();
+  BPos += A.getCentre();
 
   return;
 }

--- a/System/generalProcess/meshConstruct.cxx
+++ b/System/generalProcess/meshConstruct.cxx
@@ -1,6 +1,6 @@
-/********************************************************************* 
+/*********************************************************************
   CombLayer : MCNP(X) Input builder
- 
+
  * File:   generalProcess/meshConstruct.cxx
  *
  * Copyright (c) 2004-2023 by Stuart Ansell
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  ****************************************************************************/
 #include <fstream>
@@ -51,7 +51,7 @@
 #include "localRotate.h"
 #include "masterRotate.h"
 
-#include "meshConstruct.h" 
+#include "meshConstruct.h"
 
 
 
@@ -62,20 +62,28 @@ namespace meshConstruct
 {
 void
 calcXYZ(const objectGroups& OGrp,
-		       const std::string& object,const std::string& linkPos,
-		       Geometry::Vec3D& APos,Geometry::Vec3D& BPos) 
+	       const std::string& object,const std::string& linkPos,
+	       Geometry::Vec3D& APos,Geometry::Vec3D& BPos,
+	       Geometry::Vec3D& origin,
+	       Geometry::Vec3D& X,Geometry::Vec3D& Y,Geometry::Vec3D& Z)
   /*!
-    Calculate the grid positions relative to an object
-    Note that for the mesh it must align on 
+    Calculate the grid positions relative to an object link point.
+    APos/BPos are offsets in the link point's local frame; this function
+    translates them to world coordinates and also returns the link point's
+    world position (origin) and orientation axes (X, Y, Z) so that callers
+    can emit ROT-DEFIni cards for mesh tallies.
     \param OGrp :: Object group
     \param object :: object name
-    \param linkPos :: link position
-    \param APos :: Lower corner [output]
-    \param BPos :: Upper corner [output]
+    \param linkPos :: link position name/index
+    \param APos :: Lower corner [in/out: local offset → world coordinate]
+    \param BPos :: Upper corner [in/out: local offset → world coordinate]
+    \param origin :: Link point world position [output]
+    \param X :: Link point X axis in world frame [output]
+    \param Y :: Link point Y axis in world frame [output]
+    \param Z :: Link point Z axis in world frame [output]
    */
 {
   ELog::RegMethod RegA("meshConstruct","calcXYZ");
-
 
   const attachSystem::FixedComp* FC=
     OGrp.getObjectThrow<attachSystem::FixedComp>(object,"FixedComp");
@@ -84,11 +92,35 @@ calcXYZ(const objectGroups& OGrp,
   attachSystem::FixedUnit A("tmpComp",0);
   A.createUnitVector(*FC,sideIndex);
 
+  origin = A.getCentre();
+  X = A.getX();
+  Y = A.getY();
+  Z = A.getZ();
+
   // APos/BPos are offsets from the mesh origin (0,0,0).
   // Translate so that the mesh origin coincides with the link point.
-  APos += A.getCentre();
-  BPos += A.getCentre();
+  APos += origin;
+  BPos += origin;
 
+  return;
+}
+
+void
+calcXYZ(const objectGroups& OGrp,
+	       const std::string& object,const std::string& linkPos,
+	       Geometry::Vec3D& APos,Geometry::Vec3D& BPos)
+  /*!
+    Calculate the grid positions relative to an object link point.
+    Convenience overload that discards the link transform information.
+    \param OGrp :: Object group
+    \param object :: object name
+    \param linkPos :: link position name/index
+    \param APos :: Lower corner [in/out]
+    \param BPos :: Upper corner [in/out]
+   */
+{
+  Geometry::Vec3D origin, X, Y, Z;
+  calcXYZ(OGrp, object, linkPos, APos, BPos, origin, X, Y, Z);
   return;
 }
 
@@ -101,7 +133,7 @@ getObjectMesh(const objectGroups& OGrp,
 			     const size_t offset,
 			     Geometry::Vec3D& APt,
 			     Geometry::Vec3D& BPt,
-			     std::array<size_t,3>& Nxyz)     
+			     std::array<size_t,3>& Nxyz)
   /*!
     Get mesh grid for the tally
     \param OGrp :: object group
@@ -116,21 +148,71 @@ getObjectMesh(const objectGroups& OGrp,
 {
   ELog::RegMethod RegA("meshConstruct","getObjectMesh");
 
-  size_t itemIndex(offset+2);   
+  size_t itemIndex(offset+2);
   const std::string place=
     IParam.getValueError<std::string>(itemName,Index,offset,"position not given");
   const std::string linkName=
-    IParam.getValueError<std::string>(itemName,Index,offset+1,"front/back/side not given");      
+    IParam.getValueError<std::string>(itemName,Index,offset+1,"front/back/side not given");
 
   APt=IParam.getCntVec3D(itemName,Index,itemIndex,"Low Corner");
   BPt=IParam.getCntVec3D(itemName,Index,itemIndex,"High Corner");
-  
+
   Nxyz[0]=IParam.getValueError<size_t>(itemName,Index,itemIndex++,"NXpts");
   Nxyz[1]=IParam.getValueError<size_t>(itemName,Index,itemIndex++,"NYpts");
   Nxyz[2]=IParam.getValueError<size_t>(itemName,Index,itemIndex++,"NZpts");
-  
+
   calcXYZ(OGrp,place,linkName,APt,BPt);
-  
+
+  return;
+}
+
+void
+getObjectMesh(const objectGroups& OGrp,
+		     const mainSystem::inputParam& IParam,
+		     const std::string& itemName,
+		     const size_t Index,
+		     const size_t offset,
+		     Geometry::Vec3D& APt,
+		     Geometry::Vec3D& BPt,
+		     std::array<size_t,3>& Nxyz,
+		     Geometry::Vec3D& linkOrigin,
+		     Geometry::Vec3D& linkX,
+		     Geometry::Vec3D& linkY,
+		     Geometry::Vec3D& linkZ)
+  /*!
+    Get mesh grid for the tally, also returning the link point
+    world position and orientation axes for ROT-DEFIni generation.
+    \param OGrp :: object group
+    \param IParam :: Main input parameters
+    \param itemName :: Name to search
+    \param Index :: index of the -T card
+    \param offset :: start point in T card to take position from
+    \param APt :: Low box corner [in/out: local offset → world coordinate]
+    \param BPt :: Upper box corner [in/out: local offset → world coordinate]
+    \param Nxyz :: number of points
+    \param linkOrigin :: Link point world position [output]
+    \param linkX :: Link point X axis [output]
+    \param linkY :: Link point Y axis [output]
+    \param linkZ :: Link point Z axis [output]
+  */
+{
+  ELog::RegMethod RegA("meshConstruct","getObjectMesh");
+
+  size_t itemIndex(offset+2);
+  const std::string place=
+    IParam.getValueError<std::string>(itemName,Index,offset,"position not given");
+  const std::string linkName=
+    IParam.getValueError<std::string>(itemName,Index,offset+1,"front/back/side not given");
+
+  APt=IParam.getCntVec3D(itemName,Index,itemIndex,"Low Corner");
+  BPt=IParam.getCntVec3D(itemName,Index,itemIndex,"High Corner");
+
+  Nxyz[0]=IParam.getValueError<size_t>(itemName,Index,itemIndex++,"NXpts");
+  Nxyz[1]=IParam.getValueError<size_t>(itemName,Index,itemIndex++,"NYpts");
+  Nxyz[2]=IParam.getValueError<size_t>(itemName,Index,itemIndex++,"NZpts");
+
+  calcXYZ(OGrp,place,linkName,APt,BPt,linkOrigin,linkX,linkY,linkZ);
+
   return;
 }
 
@@ -160,25 +242,25 @@ getFreeMesh(const mainSystem::inputParam& IParam,
 
   APt=IParam.getCntVec3D(itemName,Index,itemIndex,"Low Corner");
   BPt=IParam.getCntVec3D(itemName,Index,itemIndex,"High Corner");
-  
+
   // Rotation:
   const std::string revStr=
     IParam.getDefValue<std::string>("",itemName,Index,itemIndex);
-  if (revStr=="r") 
+  if (revStr=="r")
     {
       ELog::EM<<"Reverse rotating"<<ELog::endDiag;
       APt=MR.reverseRotate(APt);
       BPt=MR.reverseRotate(BPt);
     }
-      
+
   Nxyz[0]=IParam.getValueError<size_t>(itemName,Index,itemIndex++,"NXpts");
   Nxyz[1]=IParam.getValueError<size_t>(itemName,Index,itemIndex++,"NYpts");
   Nxyz[2]=IParam.getValueError<size_t>(itemName,Index,itemIndex++,"NZpts");
 
   return;
 }
-  
-const std::string& 
+
+const std::string&
 getDoseConversion()
   /*!
     Return the dose string  for a mshtr
@@ -209,7 +291,7 @@ getDoseConversion()
   return fcdString;
 }
 
-const std::string& 
+const std::string&
 getPhotonDoseConversion()
   /*!
     Return the dose string  for a mshtr
@@ -238,9 +320,9 @@ getPhotonDoseConversion()
 
   return fcdString;
 }
-  
+
 void
-writeHelp(std::ostream& OX) 
+writeHelp(std::ostream& OX)
   /*!
     Write out help
     \param OX :: Output stream

--- a/System/generalProcessInc/meshConstruct.h
+++ b/System/generalProcessInc/meshConstruct.h
@@ -55,6 +55,12 @@ namespace meshConstruct
 		      const std::string&,const std::string&,
 		      Geometry::Vec3D&,Geometry::Vec3D&) ;
 
+   void calcXYZ(const objectGroups&,
+		      const std::string&,const std::string&,
+		      Geometry::Vec3D&,Geometry::Vec3D&,
+		      Geometry::Vec3D&,
+		      Geometry::Vec3D&,Geometry::Vec3D&,Geometry::Vec3D&);
+
    void getObjectMesh(const objectGroups&,
 			    const mainSystem::inputParam&,
 			    const std::string&,
@@ -62,6 +68,16 @@ namespace meshConstruct
 			    Geometry::Vec3D&,
 			    Geometry::Vec3D&,
 			    std::array<size_t,3>&);
+
+   void getObjectMesh(const objectGroups&,
+			    const mainSystem::inputParam&,
+			    const std::string&,
+			    const size_t,const size_t,
+			    Geometry::Vec3D&,
+			    Geometry::Vec3D&,
+			    std::array<size_t,3>&,
+			    Geometry::Vec3D&,
+			    Geometry::Vec3D&,Geometry::Vec3D&,Geometry::Vec3D&);
 
    void getFreeMesh(const mainSystem::inputParam&,
 			  const std::string&,


### PR DESCRIPTION
In CombLayer, FLUKA USRBIN estimators can be created either in the absolute coordinate system or relative to a link point. In the latter case, the USRBIN mesh should follow the geometry translation and rotation, and this PR implements that functionality.

If the transformed USRBIN mesh is not parallel to the main coordinate axes, its translation and rotation are defined using the ROT-DEFI and ROTPBIN cards. Otherwise, when the mesh remains parallel to the main axes, these cards are not used; instead, the minimum and maximum mesh coordinates are recalculated directly in the new coordinate system.

The behaviour can be demonstrated with the following command, where a vacuum pipe geometry is rotated around an arbitrary axis:

```
./singleItem --singleItem VacuumPipe -T mymesh mesh dose-eq object VC \#front \
   'Vec3D(-5,5,-10)' 'Vec3D(10,70,20)' 10 20 30 -angle freeAxis 'Vec3D(-5,7,-10)'  30 -fluka pipe
```